### PR TITLE
fix(backend): configure CORS via ALLOWED_ORIGINS with dev permissive fallback

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,7 +2,7 @@ PORT=3000
 ALLOWED_ASSETS="USDC,XLM,ARS"
 
 # CORS allowed origins (comma-separated)
-CORS_ALLOWED_ORIGINS="http://localhost:5173"
+ALLOWED_ORIGINS="http://localhost:5173"
 
 # Soroban contract pledge flow
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org:443

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -24,9 +24,7 @@ export const config = {
     .split(",")
     .map((value) => value.trim().toUpperCase())
     .filter(Boolean),
-  corsAllowedOrigins: parseOrigins(
-    process.env.CORS_ALLOWED_ORIGINS ?? "http://localhost:5173",
-  ),
+  corsAllowedOrigins: parseOrigins(process.env.ALLOWED_ORIGINS ?? ""),
   sorobanRpcUrl: process.env.SOROBAN_RPC_URL ?? "https://soroban-testnet.stellar.org:443",
   contractId: process.env.CONTRACT_ID ?? "",
   sorobanNetworkPassphrase:

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -49,14 +49,20 @@ type CampaignListItem =
   ? ReturnType<typeof listCampaigns>[number] & { progress: Progress }
   : never;
 
-<
-
 app.use(
   cors({
-    origin: config.corsAllowedOrigins,
+    origin: (origin, callback) => {
+      const isDev = process.env.NODE_ENV !== "production";
+      if (!origin || config.corsAllowedOrigins.includes(origin) || (isDev && config.corsAllowedOrigins.length === 0)) {
+        callback(null, true);
+      } else {
+        callback(new Error("Not allowed by CORS"));
+      }
+    },
     credentials: true,
   }),
 );
+
 app.use(express.json());
 
 app.use((req: Request & { requestId?: string }, _res: Response, next: express.NextFunction) => {
@@ -393,6 +399,17 @@ app.get("/api/config", (_req: Request, res: Response) => {
 });
 
 app.use((err: any, req: Request, res: Response, _next: express.NextFunction) => {
+  if (err.message === "Not allowed by CORS") {
+    return res.status(403).json({
+      success: false,
+      error: {
+        code: "FORBIDDEN",
+        message: "CORS policy violation",
+        requestId: (req as any).requestId,
+      },
+    });
+  }
+
   const statusCode = err instanceof AppError ? err.statusCode : (err.statusCode ?? 500);
   const code = err instanceof AppError ? err.code : (err.code ?? "INTERNAL_SERVER_ERROR");
   const response: ApiErrorResponse = {

--- a/backend/tests/SETUP.md
+++ b/backend/tests/SETUP.md
@@ -304,7 +304,7 @@ NODE_ENV=test                    # Optional
 ### Optional
 
 ```bash
-CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org:443
 NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 CONTRACT_AMOUNT_DECIMALS=2


### PR DESCRIPTION
Closes #98

The CORS setup used hardcoded permissive behavior that isn’t safe for production.
This PR switches CORS origin control to the `ALLOWED_ORIGINS` environment variable.

You can now provide a comma-separated list of allowed origins, and requests are validated against that list. In development, when `ALLOWED_ORIGINS` is unset, behavior remains permissive to avoid breaking local workflows.

Invalid origins now return a proper `403` response.

**Files touched**
- `backend/src/config.ts`
- `backend/src/index.ts`
- `backend/.env.example`
- `backend/tests/SETUP.md`

**Acceptance criteria**
- `ALLOWED_ORIGINS` controls allowed origins
- Comma-separated multiple origins supported
- Development default remains permissive
- Invalid CORS requests return `403`