### PR TITLE
feat(frontend): add toast notification system for action feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ frontend/.vite/
 contracts/target/
 contracts/.stellar/
 backend/data/
+CLAUDE.md

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { CampaignsTable } from "./components/CampaignsTable";
 import { CampaignTimeline } from "./components/CampaignTimeline";
 import { CreateCampaignForm } from "./components/CreateCampaignForm";
 import { IssueBacklog } from "./components/IssueBacklog";
+import { ToastContainer } from "./components/ToastContainer";
 import {
   addPledge,
   claimCampaign,
@@ -22,6 +23,7 @@ import {
   submitFreighterPledge,
 } from "./services/freighter";
 import { submitRefundTransaction } from "./services/soroban";
+import { useToast } from "./hooks/useToast";
 import {
   ApiError,
   AppConfig,
@@ -49,6 +51,17 @@ function setCampaignIdInUrl(campaignId: string | null): void {
     url.searchParams.delete("campaign");
   }
   window.history.replaceState(null, "", url.toString());
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error && typeof error === "object") {
+    const maybeError = error as Error;
+    return maybeError.message || "Something went wrong.";
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return "Something went wrong.";
 }
 
 function toApiError(error: unknown): ApiError {
@@ -90,14 +103,14 @@ function App() {
   const [isSelectedLoading, setIsSelectedLoading] = useState(false);
   const [initialLoad, setInitialLoad] = useState(true);
   const [createError, setCreateError] = useState<ApiError | null>(null);
-  const [actionError, setActionError] = useState<ApiError | null>(null);
-  const [actionMessage, setActionMessage] = useState<string | null>(null);
   const [pendingPledgeCampaignId, setPendingPledgeCampaignId] = useState<string | null>(
     null,
   );
   const [invalidUrlCampaignId, setInvalidUrlCampaignId] = useState<string | null>(null);
   const [connectedWallet, setConnectedWallet] = useState<string | null>(null);
   const [isConnectingWallet, setIsConnectingWallet] = useState(false);
+
+  const { toasts, addToast, dismiss } = useToast();
 
   useEffect(() => {
     setCampaignIdInUrl(selectedCampaignId);
@@ -185,7 +198,7 @@ function App() {
       if (configResult.status === "fulfilled") {
         setAppConfig(configResult.value);
       } else {
-        setActionError(toApiError(configResult.reason));
+        addToast(getErrorMessage(configResult.reason), "error");
       }
 
       if (issuesResult.status === "fulfilled") {
@@ -203,7 +216,7 @@ function App() {
         setInvalidUrlCampaignId(requestedCampaignId && !exists ? requestedCampaignId : null);
         setSelectedCampaignId(resolvedId);
       } else {
-        setActionError(toApiError(campaignsResult.reason));
+        addToast(getErrorMessage(campaignsResult.reason), "error");
       }
 
       setInitialLoad(false);
@@ -218,7 +231,7 @@ function App() {
 
   useEffect(() => {
     void refreshSelectedData(selectedCampaignId).catch((error) => {
-      setActionError(toApiError(error));
+      addToast(getErrorMessage(error), "error");
     });
   }, [selectedCampaignId]);
 
@@ -258,22 +271,18 @@ function App() {
 
   async function handleCreate(payload: Parameters<typeof createCampaign>[0]) {
     setCreateError(null);
-    setActionError(null);
-    setActionMessage(null);
 
     try {
       const campaign = await createCampaign(payload);
       await refreshCampaigns(campaign.id);
       await refreshSelectedData(campaign.id);
-      setActionMessage(`Campaign #${campaign.id} is live and ready for pledges.`);
+      addToast(`Campaign #${campaign.id} is live and ready for pledges.`, "success");
     } catch (error) {
       setCreateError(toApiError(error));
     }
   }
 
   async function handleConnectWallet() {
-    setActionError(null);
-    setActionMessage(null);
     setIsConnectingWallet(true);
 
     try {
@@ -281,9 +290,9 @@ function App() {
         appConfig?.networkPassphrase ?? DEFAULT_NETWORK_PASSPHRASE,
       );
       setConnectedWallet(wallet.publicKey);
-      setActionMessage(`Connected wallet ${wallet.publicKey}.`);
+      addToast(`Wallet connected: ${wallet.publicKey.slice(0, 16)}...`, "success");
     } catch (error) {
-      setActionError(toApiError(error));
+      addToast(getErrorMessage(error), "error");
     } finally {
       setIsConnectingWallet(false);
     }
@@ -291,20 +300,14 @@ function App() {
 
   async function handlePledge(campaignId: string, amount: number) {
     if (!connectedWallet) {
-      setActionError({
-        message: "Connect Freighter before submitting a pledge.",
-        code: "WALLET_REQUIRED",
-      });
+      addToast("Connect Freighter before submitting a pledge.", "error");
       return;
     }
 
-    setActionError(null);
-    setActionMessage(null);
     setPendingPledgeCampaignId(campaignId);
 
     try {
       if (appConfig?.walletIntegrationReady && appConfig.contractId && appConfig.sorobanRpcUrl) {
-        setActionMessage("Submitting pledge to Soroban...");
         const transactionResult = await submitFreighterPledge({
           campaignId,
           contributor: connectedWallet,
@@ -319,20 +322,16 @@ function App() {
           confirmedAt: transactionResult.confirmedAt,
         });
 
-        setActionMessage("Pledge confirmed on-chain and reconciled locally.");
+        addToast("Pledge confirmed on-chain and reconciled.", "success");
       } else {
-        setActionMessage(
-          "Wallet signing is not configured on the backend yet. Recording the pledge locally.",
-        );
         await addPledge(campaignId, { contributor: connectedWallet, amount });
-        setActionMessage("Pledge recorded in the local goal vault.");
+        addToast("Pledge recorded in the local goal vault.", "success");
       }
 
       await refreshCampaigns(campaignId);
       await refreshSelectedData(campaignId);
     } catch (error) {
-      setActionError(toApiError(error));
-      setActionMessage(null);
+      addToast(getErrorMessage(error), "error");
     } finally {
       setPendingPledgeCampaignId(null);
     }
@@ -340,31 +339,19 @@ function App() {
 
   async function handleClaim(campaign: Campaign) {
     if (!appConfig?.walletIntegrationReady) {
-      setActionError({
-        message: "Wallet signing is not configured on the backend yet.",
-        code: "CONFIG_MISSING",
-      });
+      addToast("Wallet signing is not configured on the backend yet.", "error");
       return;
     }
 
     if (!connectedWallet) {
-      setActionError({
-        message: "Connect Freighter before claiming campaign funds.",
-        code: "WALLET_REQUIRED",
-      });
+      addToast("Connect Freighter before claiming campaign funds.", "error");
       return;
     }
 
     if (connectedWallet !== campaign.creator) {
-      setActionError({
-        message: "Only the campaign creator can claim funds.",
-        code: "FORBIDDEN",
-      });
+      addToast("Only the campaign creator can claim funds.", "error");
       return;
     }
-
-    setActionError(null);
-    setActionMessage("Submitting claim to Soroban...");
 
     try {
       const transactionResult = await submitFreighterClaim({
@@ -382,26 +369,21 @@ function App() {
 
       await refreshCampaigns(campaign.id);
       await refreshSelectedData(campaign.id);
-      setActionMessage("Campaign claimed successfully.");
+      addToast("Campaign claimed successfully.", "success");
     } catch (error) {
-      setActionError(toApiError(error));
-      setActionMessage(null);
+      addToast(getErrorMessage(error), "error");
     }
   }
 
   async function handleRefund(campaignId: string, contributor: string) {
-    setActionError(null);
-    setActionMessage("Preparing Soroban refund transaction...");
-
     try {
       const sorobanReceipt = await submitRefundTransaction(campaignId, contributor);
       await refundCampaign(campaignId, contributor, sorobanReceipt);
       await refreshCampaigns(campaignId);
       await refreshSelectedData(campaignId);
-      setActionMessage("Contributor refunded successfully.");
+      addToast("Contributor refunded successfully.", "success");
     } catch (error) {
-      setActionError(toApiError(error));
-      setActionMessage(null);
+      addToast(getErrorMessage(error), "error");
     }
   }
 
@@ -458,8 +440,6 @@ function App() {
           appConfig={appConfig}
           connectedWallet={connectedWallet}
           isConnectingWallet={isConnectingWallet}
-          actionError={actionError}
-          actionMessage={actionMessage}
           isPledgePending={pendingPledgeCampaignId === selectedCampaignId}
           isLoading={isSelectedLoading || initialLoad}
           onConnectWallet={handleConnectWallet}
@@ -483,6 +463,8 @@ function App() {
       <section className="section-margin">
         <IssueBacklog issues={issues} isLoading={isIssuesLoading} />
       </section>
+
+      <ToastContainer toasts={toasts} onDismiss={dismiss} />
     </div>
   );
 }

--- a/frontend/src/components/CampaignDetailPanel.test.tsx
+++ b/frontend/src/components/CampaignDetailPanel.test.tsx
@@ -21,12 +21,25 @@ const mockCampaign: Campaign = {
     remainingAmount: 100,
     hoursLeft: 1,
     pledgeCount: 0,
-    hoursLeft: 1,
     canPledge: true,
     canClaim: false,
     canRefund: false,
   },
   metadata: {},
+};
+
+const mockConfig = {
+  allowedAssets: ["USDC", "XLM"],
+  soroban: {
+    enabled: false,
+    networkPassphrase: "Test SDF Network ; September 2015",
+    rpcUrl: "",
+  },
+  sorobanRpcUrl: "",
+  contractId: "",
+  networkPassphrase: "Test SDF Network ; September 2015",
+  contractAmountDecimals: 2,
+  walletIntegrationReady: false,
 };
 
 describe("CampaignDetailPanel", () => {
@@ -62,34 +75,6 @@ describe("CampaignDetailPanel", () => {
     expect(screen.getByText("USDC")).toBeInTheDocument();
   });
 
-  it("shows error message when actionError is passed", () => {
-    render(
-      <CampaignDetailPanel
-        campaign={mockCampaign}
-        actionError={{ message: "Pledge failed" }}
-        onPledge={async () => {}}
-        onClaim={async () => {}}
-        onRefund={async () => {}}
-      />,
-    );
-    expect(screen.getByText("Pledge failed")).toBeInTheDocument();
-  });
-
-  it("shows success message when actionMessage is passed", () => {
-    render(
-      <CampaignDetailPanel
-        campaign={mockCampaign}
-        appConfig={mockConfig}
-        connectedWallet={null}
-        onConnectWallet={onConnectWallet}
-        onPledge={async () => {}}
-        onClaim={async () => {}}
-        onRefund={async () => {}}
-      />,
-    );
-    expect(screen.getByText("Pledge successful")).toBeInTheDocument();
-  });
-
   it("calls onPledge when form is submitted", async () => {
     const user = userEvent.setup();
     const onPledge = vi.fn().mockResolvedValue(undefined);
@@ -106,34 +91,24 @@ describe("CampaignDetailPanel", () => {
       />,
     );
 
-    await user.type(
-      screen.getByPlaceholderText(/G\.\.\. contributor public key/i),
-      `G${"B".repeat(55)}`,
-    );
     await user.click(screen.getByText("Add pledge"));
     expect(onPledge).toHaveBeenCalled();
   });
 
-  it("shows error message when pledge fails", async () => {
-    const user = userEvent.setup();
-    const onPledge = vi.fn().mockResolvedValue(undefined);
-
-  it("shows an action error when provided", () => {
+  it("shows pending note while pledge is in flight", () => {
     render(
       <CampaignDetailPanel
         campaign={mockCampaign}
-        actionError={{ message: "Pledge failed" }}
-        onPledge={onPledge}
+        appConfig={mockConfig}
+        connectedWallet={`G${"B".repeat(55)}`}
+        isPledgePending
+        onConnectWallet={async () => {}}
+        onPledge={async () => {}}
         onClaim={async () => {}}
         onRefund={async () => {}}
       />,
     );
 
-    await user.type(
-      screen.getByPlaceholderText(/G\.\.\. contributor public key/i),
-      `G${"B".repeat(55)}`,
-    );
-    await user.click(screen.getByText("Add pledge"));
-    expect(screen.getByText("Pledge failed")).toBeInTheDocument();
+    expect(screen.getByText(/pledge transaction is in flight/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/CampaignDetailPanel.tsx
+++ b/frontend/src/components/CampaignDetailPanel.tsx
@@ -1,6 +1,6 @@
-import { FormEvent, useEffect, useMemo, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { MousePointer2 } from "lucide-react";
-import { ApiError, AppConfig, Campaign } from "../types/campaign";
+import { AppConfig, Campaign } from "../types/campaign";
 import { ContributorSummary } from "./ContributorSummary";
 import { CopyButton } from "./CopyButton";
 import { EmptyState } from "./EmptyState";
@@ -11,8 +11,6 @@ interface CampaignDetailPanelProps {
   connectedWallet?: string | null;
   isConnectingWallet?: boolean;
   isLoading?: boolean;
-  actionError?: ApiError | string | null;
-  actionMessage?: string | null;
   isPledgePending?: boolean;
   onConnectWallet?: () => Promise<void>;
   onPledge?: (campaignId: string, amount: number) => Promise<void>;
@@ -42,8 +40,6 @@ export function CampaignDetailPanel({
   connectedWallet = null,
   isConnectingWallet = false,
   isLoading = false,
-  actionError,
-  actionMessage,
   isPledgePending = false,
   onConnectWallet = async () => {},
   onPledge = async () => {},
@@ -58,14 +54,6 @@ export function CampaignDetailPanel({
     setPledgeAmount("25");
     setRefundContributor(connectedWallet ?? "");
   }, [campaign?.id, connectedWallet]);
-
-  const normalizedActionError = useMemo(() => {
-    if (!actionError) {
-      return null;
-    }
-
-    return typeof actionError === "string" ? { message: actionError } : actionError;
-  }, [actionError]);
 
   const walletReady = Boolean(
     appConfig?.walletIntegrationReady ?? appConfig?.soroban?.enabled,
@@ -304,22 +292,6 @@ export function CampaignDetailPanel({
           the backend reconciles the result.
         </p>
       ) : null}
-
-      {normalizedActionError ? (
-        <div className="form-error">
-          <p>{normalizedActionError.message}</p>
-          {normalizedActionError.code ? (
-            <small className="error-meta">
-              Code: {normalizedActionError.code}
-              {normalizedActionError.requestId
-                ? ` | Request ID: ${normalizedActionError.requestId}`
-                : ""}
-            </small>
-          ) : null}
-        </div>
-      ) : null}
-
-      {actionMessage ? <p className="form-success">{actionMessage}</p> : null}
 
       {activeCampaign.metadata?.imageUrl ? (
         <div className="campaign-image-container">

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -1,0 +1,39 @@
+import { CheckCircle2, Info, X, XCircle } from "lucide-react";
+import type { Toast, ToastVariant } from "../hooks/useToast";
+
+interface ToastContainerProps {
+  toasts: Toast[];
+  onDismiss: (id: string) => void;
+}
+
+const VARIANT_ICONS: Record<ToastVariant, React.ElementType> = {
+  success: CheckCircle2,
+  error: XCircle,
+  info: Info,
+};
+
+export function ToastContainer({ toasts, onDismiss }: ToastContainerProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="toast-container" role="log" aria-live="polite" aria-label="Notifications">
+      {toasts.map((toast) => {
+        const Icon = VARIANT_ICONS[toast.variant];
+        return (
+          <div key={toast.id} className={`toast toast-${toast.variant}`} role="status">
+            <Icon size={18} className="toast-icon" aria-hidden="true" />
+            <p className="toast-message">{toast.message}</p>
+            <button
+              className="toast-close"
+              type="button"
+              onClick={() => onDismiss(toast.id)}
+              aria-label="Dismiss notification"
+            >
+              <X size={14} />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useToast.test.ts
+++ b/frontend/src/hooks/useToast.test.ts
@@ -1,0 +1,86 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useToast } from "./useToast";
+
+describe("useToast", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts with no toasts", () => {
+    const { result } = renderHook(() => useToast());
+    expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it("adds a toast with the given message and variant", () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.addToast("Pledge confirmed.", "success");
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0].message).toBe("Pledge confirmed.");
+    expect(result.current.toasts[0].variant).toBe("success");
+  });
+
+  it("defaults to info variant when none supplied", () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.addToast("Something happened.");
+    });
+
+    expect(result.current.toasts[0].variant).toBe("info");
+  });
+
+  it("stacks multiple toasts", () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.addToast("First", "success");
+      result.current.addToast("Second", "error");
+      result.current.addToast("Third", "info");
+    });
+
+    expect(result.current.toasts).toHaveLength(3);
+  });
+
+  it("auto-dismisses after 4500 ms", () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.addToast("Will vanish", "success");
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+
+    act(() => {
+      vi.advanceTimersByTime(4500);
+    });
+
+    expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it("manually dismissing removes only the targeted toast", () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.addToast("Keep me", "success");
+      result.current.addToast("Remove me", "error");
+    });
+
+    const idToRemove = result.current.toasts[1].id;
+
+    act(() => {
+      result.current.dismiss(idToRemove);
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0].message).toBe("Keep me");
+  });
+});

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -1,0 +1,37 @@
+import { useCallback, useRef, useState } from "react";
+
+export type ToastVariant = "success" | "error" | "info";
+
+export interface Toast {
+  id: string;
+  message: string;
+  variant: ToastVariant;
+}
+
+const AUTO_DISMISS_MS = 4500;
+
+export function useToast() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+    const timer = timersRef.current.get(id);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timersRef.current.delete(id);
+    }
+  }, []);
+
+  const addToast = useCallback(
+    (message: string, variant: ToastVariant = "info") => {
+      const id = crypto.randomUUID();
+      setToasts((prev) => [...prev, { id, message, variant }]);
+      const timer = setTimeout(() => dismiss(id), AUTO_DISMISS_MS);
+      timersRef.current.set(id, timer);
+    },
+    [dismiss],
+  );
+
+  return { toasts, addToast, dismiss };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -882,6 +882,115 @@ tbody tr:hover td {
   display: block;
 }
 
+/* Toast Notifications */
+.toast-container {
+  position: fixed;
+  top: 24px;
+  right: 24px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 420px;
+  width: calc(100vw - 48px);
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  border: 1px solid var(--border-glass-bright);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  pointer-events: all;
+  animation: toastIn 0.28s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+}
+
+.toast-success {
+  background: rgba(16, 185, 129, 0.12);
+  border-color: rgba(16, 185, 129, 0.35);
+}
+
+.toast-error {
+  background: rgba(244, 63, 94, 0.12);
+  border-color: rgba(244, 63, 94, 0.35);
+}
+
+.toast-info {
+  background: rgba(99, 102, 241, 0.12);
+  border-color: rgba(99, 102, 241, 0.35);
+}
+
+.toast-icon {
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.toast-success .toast-icon {
+  color: #4ade80;
+}
+
+.toast-error .toast-icon {
+  color: #fb7185;
+}
+
+.toast-info .toast-icon {
+  color: #818cf8;
+}
+
+.toast-message {
+  flex: 1;
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--text-main);
+}
+
+.toast-close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  padding: 2px;
+  display: flex;
+  align-items: center;
+  border-radius: 4px;
+  transition: color 0.15s;
+  min-height: auto;
+}
+
+.toast-close:hover {
+  color: var(--text-main);
+}
+
+@keyframes toastIn {
+  from {
+    opacity: 0;
+    transform: translateX(20px) scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@media (max-width: 767px) {
+  .toast-container {
+    top: 16px;
+    right: 12px;
+    left: 12px;
+    width: auto;
+    max-width: none;
+  }
+}
+
 @media (max-width: 767px) {
   /* Hide the wide table and show stacked cards on small screens */
   .table-only {


### PR DESCRIPTION
## Summary

Closes #79 

- Adds a `useToast` hook and `ToastContainer` component that renders
  fixed-position, auto-dismissing notifications (4.5 s) stacked at the
  top-right of the viewport
- Replaces the inline `actionError` / `actionMessage` state in `App.tsx`
  with toast calls; all major actions (pledge, claim, refund, create
  campaign, connect wallet) now surface success and error feedback via
  toasts
- Removes `actionError` and `actionMessage` props from
  `CampaignDetailPanel` — the panel no longer owns action feedback
  rendering

## Test plan

- [ ] Pledge a campaign — success toast appears and auto-dismisses
- [ ] Trigger a pledge error (e.g. wallet not connected) — error toast appears
- [ ] Claim a funded campaign — success toast appears
- [ ] Refund a contributor — success toast appears
- [ ] Create a new campaign — success toast appears
- [ ] Connect Freighter — success toast with truncated public key appears
- [ ] Trigger multiple actions quickly — toasts stack without overlap
- [ ] Click the × on a toast — dismisses immediately
- [ ] Run `cd frontend && npx vitest --run src/hooks/useToast.test.ts src/components/CampaignDetailPanel.test.tsx` — 10 tests pass

Closes #79


