### PR TITLE
Feature/toggle dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,3 +215,12 @@ That issue is already represented in:
 - Index on-chain events into SQLite
 - Add filters, sorting, and campaign pages
 - Add contract tests and backend integration tests
+
+## New feature: Dark mode toggle
+
+The frontend now includes a theme toggle in the header with icon controls for light/dark mode.
+
+- Toggle between light and dark themes directly in the UI
+- Persist selected theme in `localStorage` using `stellar-goal-vault-theme`
+- Respect system `prefers-color-scheme` on first load when no saved theme exists
+- Apply dark/light color variants across core UI surfaces (cards, tables, forms, buttons, and controls)

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1056,7 +1056,6 @@
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4016,7 +4015,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4193,7 +4191,6 @@
       "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "1.6.1",
         "@vitest/runner": "1.6.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { Moon, Sun } from "lucide-react";
 import { CampaignDetailPanel } from "./components/CampaignDetailPanel";
 import { CampaignsTable } from "./components/CampaignsTable";
 import { CampaignTimeline } from "./components/CampaignTimeline";
@@ -31,6 +32,8 @@ import {
 } from "./types/campaign";
 
 const DEFAULT_NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+const THEME_STORAGE_KEY = "stellar-goal-vault-theme";
+type ThemeMode = "light" | "dark";
 
 function round(value: number): number {
   return Number(value.toFixed(2));
@@ -74,6 +77,15 @@ function toApiError(error: unknown): ApiError {
   return { message: "Something went wrong." };
 }
 
+function getInitialThemeMode(): ThemeMode {
+  const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+  if (storedTheme === "light" || storedTheme === "dark") {
+    return storedTheme;
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
 function App() {
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
   const [issues, setIssues] = useState<OpenIssue[]>([]);
@@ -98,6 +110,12 @@ function App() {
   const [invalidUrlCampaignId, setInvalidUrlCampaignId] = useState<string | null>(null);
   const [connectedWallet, setConnectedWallet] = useState<string | null>(null);
   const [isConnectingWallet, setIsConnectingWallet] = useState(false);
+  const [themeMode, setThemeMode] = useState<ThemeMode>(() => getInitialThemeMode());
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = themeMode;
+    window.localStorage.setItem(THEME_STORAGE_KEY, themeMode);
+  }, [themeMode]);
 
   useEffect(() => {
     setCampaignIdInUrl(selectedCampaignId);
@@ -410,10 +428,25 @@ function App() {
     setSelectedCampaignId(campaignId);
   }
 
+  function handleThemeToggle() {
+    setThemeMode((current) => (current === "dark" ? "light" : "dark"));
+  }
+
   return (
     <div className="app-shell">
       <header className="hero">
-        <p className="eyebrow">Soroban crowdfunding MVP</p>
+        <div className="hero-topline">
+          <p className="eyebrow">Soroban crowdfunding MVP</p>
+          <button
+            type="button"
+            className="btn-ghost theme-toggle"
+            onClick={handleThemeToggle}
+            aria-label={`Switch to ${themeMode === "dark" ? "light" : "dark"} mode`}
+            title={`Switch to ${themeMode === "dark" ? "light" : "dark"} mode`}
+          >
+            {themeMode === "dark" ? <Sun size={18} /> : <Moon size={18} />}
+          </button>
+        </div>
         <h1>Stellar Goal Vault</h1>
         <p className="hero-copy">
           Create funding goals, collect pledges, and reconcile claim and refund flows

--- a/frontend/src/components/AssetFilterDropdown.tsx
+++ b/frontend/src/components/AssetFilterDropdown.tsx
@@ -17,17 +17,8 @@ export function AssetFilterDropdown({
       onChange={(e) => onChange(e.target.value)}
       disabled={disabled}
       aria-label="Filter by asset"
-      style={{
-        padding: "8px 12px",
-        border: "1px solid #cbd5e1",
-        borderRadius: "12px",
-        background: "#ffffff",
-        font: "inherit",
-        fontSize: "0.9rem",
-        color: "#14213d",
-        cursor: disabled ? "not-allowed" : "pointer",
-        opacity: disabled ? 0.55 : 1,
-      }}
+      className="control-select"
+      style={{ cursor: disabled ? "not-allowed" : "pointer", opacity: disabled ? 0.55 : 1 }}
     >
       <option value="">All Assets</option>
       {options.map((code) => (

--- a/frontend/src/components/SortDropdown.tsx
+++ b/frontend/src/components/SortDropdown.tsx
@@ -17,17 +17,8 @@ export function SortDropdown({
       onChange={(e) => onChange(e.target.value as SortOption)}
       disabled={disabled}
       aria-label="Sort campaigns"
-      style={{
-        padding: "8px 12px",
-        border: "1px solid #cbd5e1",
-        borderRadius: "12px",
-        background: "#ffffff",
-        font: "inherit",
-        fontSize: "0.9rem",
-        color: "#14213d",
-        cursor: disabled ? "not-allowed" : "pointer",
-        opacity: disabled ? 0.55 : 1,
-      }}
+      className="control-select"
+      style={{ cursor: disabled ? "not-allowed" : "pointer", opacity: disabled ? 0.55 : 1 }}
     >
       <option value="newest">Newest</option>
       <option value="deadline">Deadline</option>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,12 +1,28 @@
 @import url("https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap");
 
 :root {
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --radius-xl: 24px;
+  --radius-lg: 16px;
+  --radius-md: 12px;
+}
+
+:root[data-theme="dark"] {
   /* Color Palette - Stellar Midnight */
   --bg-deep: #0f172a;
   --bg-surface: rgba(30, 41, 59, 0.7);
   --bg-glass: rgba(255, 255, 255, 0.03);
   --border-glass: rgba(255, 255, 255, 0.1);
   --border-glass-bright: rgba(255, 255, 255, 0.2);
+  --bg-input: rgba(15, 23, 42, 0.5);
+  --bg-input-focus: rgba(15, 23, 42, 0.7);
+  --bg-row: rgba(255, 255, 255, 0.02);
+  --bg-row-hover: rgba(255, 255, 255, 0.04);
+  --bg-table-head: #f8fafc;
+  --bg-panel-soft: #f0fdf9;
+  --bg-panel-strong: #ffffff;
+  --bg-note: #fffbeb;
+  --text-on-light-surface: #14213d;
 
   --primary: #6366f1;
   --primary-glow: rgba(99, 102, 241, 0.5);
@@ -16,13 +32,78 @@
   --text-main: #f8fafc;
   --text-muted: #94a3b8;
   --text-dim: #64748b;
+  --text-warning: #92400e;
+  --text-refunded: #9a3412;
+  --timeline-pending: #f59e0b;
 
   --card-shadow: 0 10px 40px -10px rgba(0, 0, 0, 0.5);
   --glass-blur: blur(12px);
+  --hero-title-start: #fff;
 
-  --radius-xl: 24px;
-  --radius-lg: 16px;
-  --radius-md: 12px;
+  --field-error: #f87171;
+  --error-bg: #7f1d1d26;
+  --error-border: #f87171;
+  --error-text: #f87171;
+  --success-bg: #14532d26;
+  --success-border: #22c55e;
+  --success-text: #86efac;
+  --empty-bg: #1e293b80;
+  --empty-border: #475569;
+  --empty-text: #94a3b8;
+  --contributor-border: #99f6e4;
+  --contributor-stat-border: #ccfbf1;
+  --contributor-table-border: #cbd5e1;
+  --contributor-table-head-border: #e2e8f0;
+  --contributor-table-row-border: #f1f5f9;
+}
+
+:root[data-theme="light"] {
+  --bg-deep: #f1f5f9;
+  --bg-surface: rgba(255, 255, 255, 0.88);
+  --bg-glass: rgba(15, 23, 42, 0.04);
+  --border-glass: rgba(15, 23, 42, 0.14);
+  --border-glass-bright: rgba(15, 23, 42, 0.22);
+  --bg-input: #ffffff;
+  --bg-input-focus: #ffffff;
+  --bg-row: rgba(15, 23, 42, 0.03);
+  --bg-row-hover: rgba(99, 102, 241, 0.08);
+  --bg-table-head: #f8fafc;
+  --bg-panel-soft: #f0fdf9;
+  --bg-panel-strong: #ffffff;
+  --bg-note: #fffbeb;
+  --text-on-light-surface: #14213d;
+
+  --primary: #4f46e5;
+  --primary-glow: rgba(79, 70, 229, 0.35);
+  --secondary: #9333ea;
+  --accent: #e11d48;
+
+  --text-main: #0f172a;
+  --text-muted: #475569;
+  --text-dim: #64748b;
+  --text-warning: #92400e;
+  --text-refunded: #9a3412;
+  --timeline-pending: #d97706;
+
+  --card-shadow: 0 14px 30px -20px rgba(15, 23, 42, 0.35);
+  --glass-blur: blur(10px);
+  --hero-title-start: #0f172a;
+
+  --field-error: #dc2626;
+  --error-bg: #fef2f2;
+  --error-border: #fecaca;
+  --error-text: #991b1b;
+  --success-bg: #ecfdf5;
+  --success-border: #bbf7d0;
+  --success-text: #065f46;
+  --empty-bg: #f8fafc;
+  --empty-border: #cbd5e1;
+  --empty-text: #475569;
+  --contributor-border: #99f6e4;
+  --contributor-stat-border: #ccfbf1;
+  --contributor-table-border: #cbd5e1;
+  --contributor-table-head-border: #e2e8f0;
+  --contributor-table-row-border: #f1f5f9;
 }
 
 body {
@@ -30,8 +111,8 @@ body {
   font-family: "Outfit", sans-serif;
   background-color: var(--bg-deep);
   background-image:
-    radial-gradient(at 0% 0%, rgba(99, 102, 241, 0.15) 0px, transparent 50%),
-    radial-gradient(at 100% 0%, rgba(168, 85, 247, 0.15) 0px, transparent 50%);
+    radial-gradient(at 0% 0%, color-mix(in srgb, var(--primary) 22%, transparent) 0px, transparent 50%),
+    radial-gradient(at 100% 0%, color-mix(in srgb, var(--secondary) 20%, transparent) 0px, transparent 50%);
   background-attachment: fixed;
   color: var(--text-main);
   min-height: 100vh;
@@ -64,6 +145,14 @@ select {
   gap: 16px;
 }
 
+.hero-topline {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
 .eyebrow {
   color: var(--primary);
   font-size: 0.75rem;
@@ -77,7 +166,7 @@ select {
   margin: 0;
   font-size: clamp(2.5rem, 6vw, 4rem);
   font-weight: 700;
-  background: linear-gradient(to right, #fff, var(--text-muted));
+  background: linear-gradient(to right, var(--hero-title-start), var(--text-muted));
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -173,7 +262,7 @@ select {
 .field-group input,
 .field-group textarea,
 .field-group select {
-  background: rgba(15, 23, 42, 0.5);
+  background: var(--bg-input);
   border: 1px solid var(--border-glass);
   border-radius: var(--radius-md);
   padding: 14px 18px;
@@ -188,30 +277,30 @@ select {
   outline: none;
   border-color: var(--primary);
   box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.15);
-  background: rgba(15, 23, 42, 0.7);
+  background: var(--bg-input-focus);
 }
 
 /* Field Error Styles */
 .field-group .input-error,
 .field-group input.input-error,
 .field-group textarea.input-error {
-  border-color: #f87171;
-  background: rgba(127, 29, 29, 0.1);
+  border-color: var(--field-error);
+  background: var(--error-bg);
 }
 
 .field-group .input-error:focus,
 .field-group input.input-error:focus,
 .field-group textarea.input-error:focus {
-  border-color: #f87171;
+  border-color: var(--field-error);
   box-shadow: 0 0 0 4px rgba(248, 113, 113, 0.15);
-  background: rgba(127, 29, 29, 0.15);
+  background: var(--error-bg);
 }
 
 .field-error {
   display: block;
   margin-top: 6px;
   font-size: 0.8125rem;
-  color: #f87171;
+  color: var(--field-error);
   font-weight: 500;
   line-height: 1.4;
 }
@@ -263,7 +352,25 @@ select {
 }
 
 .btn-ghost:hover:not(:disabled) {
-  background: #f8fafc;
+  background: var(--bg-row-hover);
+}
+
+.theme-toggle {
+  min-height: 42px;
+  min-width: 42px;
+  width: 42px;
+  padding: 0;
+  font-size: 0.85rem;
+}
+
+.control-select {
+  padding: 8px 12px;
+  border: 1px solid var(--border-glass);
+  border-radius: 12px;
+  background: var(--bg-surface);
+  font: inherit;
+  font-size: 0.9rem;
+  color: var(--text-main);
 }
 
 .btn-primary:disabled,
@@ -282,15 +389,15 @@ select {
 }
 
 .form-error {
-  color: #991b1b;
-  background: #fef2f2;
-  border: 1px solid #fecaca;
+  color: var(--error-text);
+  background: var(--error-bg);
+  border: 1px solid var(--error-border);
 }
 
 .form-success {
-  color: #065f46;
-  background: #ecfdf5;
-  border: 1px solid #bbf7d0;
+  color: var(--success-text);
+  background: var(--success-bg);
+  border: 1px solid var(--success-border);
 }
 
 .form-error {
@@ -325,8 +432,8 @@ select {
 }
 
 .pending-note {
-  color: #92400e;
-  background: #fffbeb;
+  color: var(--text-warning);
+  background: var(--bg-note);
   border: 1px solid #fcd34d;
   border-radius: 12px;
   padding: 12px 14px;
@@ -334,9 +441,9 @@ select {
 }
 
 .empty-state {
-  color: #475569;
-  background: #f8fafc;
-  border: 1px dashed #cbd5e1;
+  color: var(--empty-text);
+  background: var(--empty-bg);
+  border: 1px dashed var(--empty-border);
 }
 
 /* Empty State Overhaul */
@@ -386,8 +493,8 @@ select {
 .contributor-summary {
   padding: 16px;
   border-radius: 14px;
-  background: #f0fdf9;
-  border: 1px solid #99f6e4;
+  background: var(--bg-panel-soft);
+  border: 1px solid var(--contributor-border);
   margin-bottom: 18px;
 }
 
@@ -415,15 +522,15 @@ select {
 .contributor-stat {
   padding: 12px;
   border-radius: 12px;
-  background: #ffffff;
-  border: 1px solid #ccfbf1;
+  background: var(--bg-panel-strong);
+  border: 1px solid var(--contributor-stat-border);
 }
 
 .contributor-stat-label {
   display: block;
   font-size: 0.78rem;
   font-weight: 600;
-  color: #475569;
+  color: var(--text-muted);
   margin-bottom: 6px;
 }
 
@@ -432,24 +539,24 @@ select {
   font-size: 0.72rem;
   line-height: 1.35;
   margin-top: 8px;
-  color: #64748b;
+  color: var(--text-dim);
 }
 
 .contributor-stat strong {
   font-size: 0.95rem;
-  color: #14213d;
+  color: var(--text-on-light-surface);
 }
 
 .contributor-summary-lead-emphasis {
   font-weight: 600;
-  color: #334155;
+  color: var(--text-muted);
 }
 
 .contributor-table-wrap {
   border-radius: 12px;
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--contributor-table-border);
   overflow: hidden;
-  background: #ffffff;
+  background: var(--bg-panel-strong);
 }
 
 .contributor-table {
@@ -457,8 +564,8 @@ select {
 }
 
 .contributor-table-head {
-  background: #f8fafc;
-  border-bottom: 1px solid #e2e8f0;
+  background: var(--bg-table-head);
+  border-bottom: 1px solid var(--contributor-table-head-border);
   font-size: 0.78rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -467,7 +574,7 @@ select {
 }
 
 .contributor-table-body .contributor-table-row:not(:last-child) {
-  border-bottom: 1px solid #f1f5f9;
+  border-bottom: 1px solid var(--contributor-table-row-border);
 }
 
 .contributor-table-row {
@@ -499,7 +606,7 @@ select {
 }
 
 .contributor-refunded {
-  color: #9a3412;
+  color: var(--text-refunded);
 }
 
 .table-wrap {
@@ -525,7 +632,7 @@ th {
 
 td {
   padding: 20px 16px;
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--bg-row);
   border-top: 1px solid var(--border-glass);
   border-bottom: 1px solid var(--border-glass);
 }
@@ -545,7 +652,7 @@ tbody tr {
 }
 
 tbody tr:hover td {
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--bg-row-hover);
   border-color: var(--border-glass-bright);
 }
 
@@ -595,7 +702,7 @@ tbody tr:hover td {
 }
 
 .timeline-item.pending .timeline-dot {
-  background: #f59e0b;
+  background: var(--timeline-pending);
 }
 
 .timeline-dot {
@@ -682,7 +789,7 @@ tbody tr:hover td {
   padding: 18px;
   border: 1px solid var(--border-glass);
   border-radius: var(--radius-md);
-  background: rgba(15, 23, 42, 0.45);
+  background: var(--bg-input);
   display: grid;
   gap: 8px;
 }
@@ -901,7 +1008,7 @@ tbody tr:hover td {
     gap: 12px;
     padding: 16px;
     border-radius: 12px;
-    background: rgba(255, 255, 255, 0.02);
+    background: var(--bg-row);
     border: 1px solid var(--border-glass);
   }
 


### PR DESCRIPTION
Closes #82

---

# Pull Request

## 🗒️ Description
This PR adds a dark mode feature to the frontend with an icon-based theme toggle in the header.  
It includes persisted theme preference using `localStorage`, system preference fallback on first load, and updated theme-aware styling for core UI surfaces (cards, tables, forms, buttons, and dropdown controls).

## 🔗 Related Issue
- Closes #<issue-number>
- Fixes #<issue-number>

## ✅ Checklist
- [x] My code follows the existing style and patterns of the project.
- [x] I have added/updated tests for my changes.
- [ ] All tests pass locally (`npm run test`).
- [x] If changing the UI, I have added screenshots/videos to this PR.
- [x] My PR has a descriptive title.

## 📸 Screenshots 
- Added dark mode and light mode video recording (header toggle, cards, table, form controls).

## 🛠️ Testing Steps
How can the reviewer verify your changes?
1. Run frontend locally with `npm run dev` in `frontend`.
2. Open `http://localhost:3000` and click the theme icon in the header to switch between dark and light mode.
3. Refresh the page and confirm selected theme persists.
4. Clear saved theme with `localStorage.removeItem("stellar-goal-vault-theme")` in browser console, refresh, and confirm system preference is used on first load.
5. Verify readability of key UI elements (cards, table rows, forms, dropdowns, and buttons) in both themes.

---
Thank you for your contribution! 🚀