### PR TITLE
feat: add campaign share button

### DIFF
--- a/frontend/src/components/CampaignDetailPanel.tsx
+++ b/frontend/src/components/CampaignDetailPanel.tsx
@@ -130,7 +130,13 @@ export function CampaignDetailPanel({
   return (
     <section className="card detail-panel">
       <div className="section-heading">
-        <h2>{activeCampaign.title}</h2>
+        <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+          <h2>{activeCampaign.title}</h2>
+          <CopyButton
+            value={`Check out this campaign: ${activeCampaign.title} (ID: ${activeCampaign.id})`}
+            ariaLabel={`Share campaign ${activeCampaign.title}`}
+          />
+        </div>
         <p className="muted">{activeCampaign.description}</p>
       </div>
 


### PR DESCRIPTION
Closes #80 

## Description
Add Campaign Share Button With Copyable Link.

This PR addresses the lack of an easy way to share specific campaigns by introducing a quick-copy mechanism directly on the campaign detail panel. 

### Changes Made
- Integrated the existing `CopyButton` component into the `CampaignDetailPanel`'s header section.
- Configured the button to copy a formatted text snippet that easily references the specified campaign, containing both the title and ID: `Check out this campaign: <Title> (ID: <ID>)`.
- Reused the existing `CopyButton` component to ensure standard, built-in visual feedback loops and keyboard accessibility without increasing the footprint of the codebase.

### Acceptance Criteria Checklist
- [x] Clicking the share button copies a shareable reference to the clipboard
- [x] Visual feedback confirms the copy succeeded
- [x] The share action is accessible by keyboard
- [x] The copied content includes at minimum the campaign title and ID
