### PR TITLE
feat(frontend): add status tabs with counts for campaign filtering

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -144,6 +144,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -506,6 +507,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -554,6 +556,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1595,7 +1598,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -1610,8 +1612,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -1687,8 +1688,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1818,6 +1818,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1829,6 +1830,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1966,7 +1968,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2208,6 +2209,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2749,8 +2751,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3454,6 +3455,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3625,7 +3627,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4022,6 +4023,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4231,6 +4233,7 @@
       "resolved": "https://registry.npmmirror.com/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4243,6 +4246,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4255,13 +4259,15 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmmirror.com/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -4361,7 +4367,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -4849,6 +4856,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5098,6 +5106,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/components/CampaignsTable.integration.test.tsx
+++ b/frontend/src/components/CampaignsTable.integration.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CampaignsTable } from "./CampaignsTable";
 import type { Campaign } from "../types/campaign";
@@ -78,7 +78,7 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
       const searchInput = screen.getByPlaceholderText("Search campaigns...");
@@ -92,7 +92,7 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
       const searchInput = screen.getByPlaceholderText("Search campaigns...");
@@ -112,7 +112,7 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
       const searchInput = screen.getByPlaceholderText("Search campaigns...");
@@ -137,7 +137,7 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
       const searchInput = screen.getByPlaceholderText("Search campaigns...");
@@ -159,7 +159,7 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
       const searchInput = screen.getByPlaceholderText("Search campaigns...");
@@ -182,7 +182,7 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
       const searchInput = screen.getByPlaceholderText("Search campaigns...");
@@ -203,10 +203,12 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
-      const searchInput = screen.getByPlaceholderText("Search campaigns...") as HTMLInputElement;
+      const searchInput = screen.getByPlaceholderText(
+        "Search campaigns...",
+      ) as HTMLInputElement;
 
       // First search
       await user.type(searchInput, "game");
@@ -234,7 +236,7 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
       const searchInput = screen.getByPlaceholderText("Search campaigns...");
@@ -255,7 +257,7 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
       const searchInput = screen.getByPlaceholderText("Search campaigns...");
@@ -292,19 +294,23 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
       const searchInput = screen.getByPlaceholderText("Search campaigns...");
 
       // Initially no clear button
-      expect(screen.queryByRole("button", { name: "Clear search" })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Clear search" }),
+      ).not.toBeInTheDocument();
 
       // Type something
       await user.type(searchInput, "test");
 
       // Now clear button should appear
-      expect(screen.getByRole("button", { name: "Clear search" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Clear search" }),
+      ).toBeInTheDocument();
     });
 
     it("should clear search and show all campaigns when clear button clicked", async () => {
@@ -315,7 +321,7 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
       const searchInput = screen.getByPlaceholderText("Search campaigns...");
@@ -349,7 +355,7 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
       const searchInput = screen.getByPlaceholderText("Search campaigns...");
@@ -375,6 +381,81 @@ describe("CampaignsTable Search Integration", () => {
     });
   });
 
+  describe("Status Filter Tabs", () => {
+    it("should show counts per status and a clear active filter", () => {
+      render(
+        <CampaignsTable
+          campaigns={mockCampaigns}
+          selectedCampaignId={null}
+          onSelect={vi.fn()}
+          isLoading={false}
+        />,
+      );
+
+      const statusTabs = screen.getByRole("tablist", {
+        name: /Filter campaigns by status/i,
+      });
+
+      const allTab = within(statusTabs).getByRole("button", {
+        name: /Status: Filter campaigns by status/i,
+      });
+      const openTab = within(statusTabs).getByRole("button", {
+        name: /Open2/i,
+      });
+      const fundedTab = within(statusTabs).getByRole("button", {
+        name: /Funded1/i,
+      });
+      const claimedTab = within(statusTabs).getByRole("button", {
+        name: /Claimed0/i,
+      });
+      const failedTab = within(statusTabs).getByRole("button", {
+        name: /Failed0/i,
+      });
+
+      expect(allTab).toHaveAttribute("aria-pressed", "true");
+      expect(openTab).toHaveAttribute("aria-pressed", "false");
+      expect(fundedTab).toHaveAttribute("aria-pressed", "false");
+      expect(claimedTab).toHaveAttribute("aria-pressed", "false");
+      expect(failedTab).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("should filter to one status at a time and allow returning to all", () => {
+      render(
+        <CampaignsTable
+          campaigns={mockCampaigns}
+          selectedCampaignId={null}
+          onSelect={vi.fn()}
+          isLoading={false}
+        />,
+      );
+
+      const statusTabs = screen.getByRole("tablist", {
+        name: /Filter campaigns by status/i,
+      });
+      const fundedTab = within(statusTabs).getByRole("button", {
+        name: /Funded1/i,
+      });
+      fireEvent.click(fundedTab);
+
+      expect(screen.getAllByText("Write a Book").length).toBeGreaterThan(0);
+      expect(screen.queryAllByText("Build a Rocket Ship")).toHaveLength(0);
+      expect(screen.queryAllByText("Create a Game")).toHaveLength(0);
+      expect(fundedTab).toHaveAttribute("aria-pressed", "true");
+
+      const allTab = within(statusTabs).getByRole("button", {
+        name: /Status: Filter campaigns by status/i,
+      });
+      fireEvent.click(allTab);
+
+      expect(screen.getAllByText("Build a Rocket Ship").length).toBeGreaterThan(
+        0,
+      );
+      expect(screen.getAllByText("Create a Game").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Write a Book").length).toBeGreaterThan(0);
+      expect(allTab).toHaveAttribute("aria-pressed", "true");
+    });
+  });
+
   describe("Empty State Messages", () => {
     it("should show appropriate message when search finds no results", async () => {
       const user = userEvent.setup({ delay: null });
@@ -384,7 +465,7 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
       const searchInput = screen.getByPlaceholderText("Search campaigns...");
@@ -394,7 +475,8 @@ describe("CampaignsTable Search Integration", () => {
       vi.advanceTimersByTime(350);
 
       // Should show no results message
-      const emptyStateText = screen.queryByText(/No campaigns found/i) ||
+      const emptyStateText =
+        screen.queryByText(/No campaigns found/i) ||
         screen.queryByText(/Try adjusting your search/i);
       // Note: Exact message depends on component implementation
       expect(screen.queryByText("Build a Rocket Ship")).not.toBeInTheDocument();
@@ -408,7 +490,7 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
       const searchInput = screen.getByPlaceholderText("Search campaigns...");
@@ -434,24 +516,27 @@ describe("CampaignsTable Search Integration", () => {
       const user = userEvent.setup({ delay: null });
 
       // Create 100 campaigns
-      const largeCampaignList: Campaign[] = Array.from({ length: 100 }, (_, i) => ({
-        id: `camp-${i.toString().padStart(3, "0")}`,
-        title: `Campaign ${i + 1}`,
-        description: `Description ${i + 1}`,
-        creator: `CREATOR${i}@stellar.org`,
-        assetCode: i % 2 === 0 ? "USDC" : "native",
-        targetAmount: 100000 * (i + 1),
-        pledgedAmount: 50000 * (i + 1),
-        deadline: "2025-12-31",
-        progress: {
-          status: "open" as const,
-          percentFunded: (i % 100) + 1,
-          hoursLeft: 240,
-          canPledge: true,
-          canClaim: false,
-          canRefund: false,
-        },
-      }));
+      const largeCampaignList: Campaign[] = Array.from(
+        { length: 100 },
+        (_, i) => ({
+          id: `camp-${i.toString().padStart(3, "0")}`,
+          title: `Campaign ${i + 1}`,
+          description: `Description ${i + 1}`,
+          creator: `CREATOR${i}@stellar.org`,
+          assetCode: i % 2 === 0 ? "USDC" : "native",
+          targetAmount: 100000 * (i + 1),
+          pledgedAmount: 50000 * (i + 1),
+          deadline: "2025-12-31",
+          progress: {
+            status: "open" as const,
+            percentFunded: (i % 100) + 1,
+            hoursLeft: 240,
+            canPledge: true,
+            canClaim: false,
+            canRefund: false,
+          },
+        }),
+      );
 
       render(
         <CampaignsTable
@@ -459,7 +544,7 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
       const searchInput = screen.getByPlaceholderText("Search campaigns...");
@@ -481,11 +566,11 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
       const searchInput = screen.getByLabelText(
-        "Search campaigns by title, creator, or ID"
+        "Search campaigns by title, creator, or ID",
       );
       expect(searchInput).toBeInTheDocument();
     });
@@ -498,7 +583,7 @@ describe("CampaignsTable Search Integration", () => {
           selectedCampaignId={null}
           onSelect={vi.fn()}
           isLoading={false}
-        />
+        />,
       );
 
       const searchInput = screen.getByPlaceholderText("Search campaigns...");

--- a/frontend/src/components/CampaignsTable.tsx
+++ b/frontend/src/components/CampaignsTable.tsx
@@ -1,12 +1,26 @@
 import { LayoutGrid } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useDebounce } from "../hooks/useDebounce";
-import { Campaign } from "../types/campaign";
+import { Campaign, CampaignStatus } from "../types/campaign";
 import { EmptyState } from "./EmptyState";
 import { AssetFilterDropdown } from "./AssetFilterDropdown";
-import { applyFilters, getDistinctAssetCodes, sortCampaigns } from "./campaignsTableUtils";
+import {
+  applyFilters,
+  getDistinctAssetCodes,
+  sortCampaigns,
+} from "./campaignsTableUtils";
 import { SearchInput } from "./SearchInput";
 import { SortDropdown, SortOption } from "./SortDropdown";
+
+type StatusFilterValue = "" | CampaignStatus;
+
+const STATUS_FILTERS: Array<{ value: StatusFilterValue; label: string }> = [
+  { value: "", label: "All" },
+  { value: "open", label: "Open" },
+  { value: "funded", label: "Funded" },
+  { value: "claimed", label: "Claimed" },
+  { value: "failed", label: "Failed" },
+];
 
 interface CampaignsTableProps {
   campaigns: Campaign[];
@@ -46,18 +60,44 @@ export function CampaignsTable({
   invalidUrlCampaignId = null,
 }: CampaignsTableProps) {
   const [assetCode, setAssetCode] = useState("");
-  const [status, setStatus] = useState("");
+  const [statusFilter, setStatusFilter] = useState<StatusFilterValue>("");
   const [sortBy, setSortBy] = useState<SortOption>("newest");
   const [searchQuery, setSearchQuery] = useState("");
   const debouncedSearchQuery = useDebounce(searchQuery, 300);
 
   const isEmpty = campaigns.length === 0;
 
-  const assetOptions = useMemo(() => getDistinctAssetCodes(campaigns), [campaigns]);
+  const assetOptions = useMemo(
+    () => getDistinctAssetCodes(campaigns),
+    [campaigns],
+  );
+  const statusCounts = useMemo(() => {
+    const counts: Record<CampaignStatus, number> = {
+      open: 0,
+      funded: 0,
+      claimed: 0,
+      failed: 0,
+    };
+
+    campaigns.forEach((campaign) => {
+      counts[campaign.progress.status] += 1;
+    });
+
+    return {
+      all: campaigns.length,
+      ...counts,
+    };
+  }, [campaigns]);
+
   const filteredCampaigns = useMemo(() => {
-    const filtered = applyFilters(campaigns, assetCode, status, debouncedSearchQuery);
+    const filtered = applyFilters(
+      campaigns,
+      assetCode,
+      statusFilter,
+      debouncedSearchQuery,
+    );
     return sortCampaigns(filtered, sortBy);
-  }, [campaigns, assetCode, status, debouncedSearchQuery, sortBy]);
+  }, [campaigns, assetCode, statusFilter, debouncedSearchQuery, sortBy]);
 
   if (isLoading && isEmpty) {
     return (
@@ -92,8 +132,8 @@ export function CampaignsTable({
 
       {invalidUrlCampaignId ? (
         <p className="banner-warn muted">
-          Campaign <code>#{invalidUrlCampaignId}</code> from the URL was not found.
-          Showing the first available campaign instead.
+          Campaign <code>#{invalidUrlCampaignId}</code> from the URL was not
+          found. Showing the first available campaign instead.
         </p>
       ) : null}
 
@@ -114,22 +154,41 @@ export function CampaignsTable({
         </label>
         <label className="field-group" style={{ minWidth: 180 }}>
           <span>Status:</span>
-          <select
-            value={status}
-            onChange={(event) => setStatus(event.target.value)}
-            disabled={isLoading}
-            aria-label="Filter by status"
+          <div
+            className="status-filter-tabs"
+            role="tablist"
+            aria-label="Filter campaigns by status"
           >
-            <option value="">All statuses</option>
-            <option value="open">Open</option>
-            <option value="funded">Funded</option>
-            <option value="claimed">Claimed</option>
-            <option value="failed">Failed</option>
-          </select>
+            {STATUS_FILTERS.map((filter) => {
+              const isActive = statusFilter === filter.value;
+              const count =
+                filter.value === ""
+                  ? statusCounts.all
+                  : statusCounts[filter.value];
+
+              return (
+                <button
+                  key={filter.label}
+                  type="button"
+                  className={`status-filter-tab ${isActive ? "status-filter-tab-active" : ""}`}
+                  onClick={() => setStatusFilter(filter.value)}
+                  aria-pressed={isActive}
+                  disabled={isLoading}
+                >
+                  <span>{filter.label}</span>
+                  <span className="status-filter-count">{count}</span>
+                </button>
+              );
+            })}
+          </div>
         </label>
         <label className="field-group" style={{ minWidth: 180 }}>
           <span>Sort:</span>
-          <SortDropdown value={sortBy} onChange={setSortBy} disabled={isLoading} />
+          <SortDropdown
+            value={sortBy}
+            onChange={setSortBy}
+            disabled={isLoading}
+          />
         </label>
       </div>
 
@@ -165,7 +224,8 @@ export function CampaignsTable({
                     <td className="mono">{campaign.creator.slice(0, 12)}...</td>
                     <td>
                       <div className="progress-copy">
-                        {campaign.pledgedAmount} / {campaign.targetAmount} {campaign.assetCode}
+                        {campaign.pledgedAmount} / {campaign.targetAmount}{" "}
+                        {campaign.assetCode}
                       </div>
                       <div className="progress-bar" aria-hidden>
                         <div
@@ -179,23 +239,31 @@ export function CampaignsTable({
                       </span>
                     </td>
                     <td>
-                      <span className={`badge badge-${campaign.progress.status}`}>
+                      <span
+                        className={`badge badge-${campaign.progress.status}`}
+                      >
                         {getStatusLabel(campaign.progress.status)}
                       </span>
                     </td>
                     <td className="stacked">
                       <span>{formatTimestamp(campaign.deadline)}</span>
-                      <span className="muted">{campaign.progress.hoursLeft}h left</span>
+                      <span className="muted">
+                        {campaign.progress.hoursLeft}h left
+                      </span>
                     </td>
                     <td>
                       <button
                         className={
-                          selectedCampaignId === campaign.id ? "btn-secondary" : "btn-ghost"
+                          selectedCampaignId === campaign.id
+                            ? "btn-secondary"
+                            : "btn-ghost"
                         }
                         type="button"
                         onClick={() => onSelect(campaign.id)}
                       >
-                        {selectedCampaignId === campaign.id ? "Selected" : "View"}
+                        {selectedCampaignId === campaign.id
+                          ? "Selected"
+                          : "View"}
                       </button>
                     </td>
                   </tr>
@@ -209,7 +277,9 @@ export function CampaignsTable({
               <article
                 key={campaign.id}
                 className={`campaign-card ${
-                  selectedCampaignId === campaign.id ? "campaign-card-selected" : ""
+                  selectedCampaignId === campaign.id
+                    ? "campaign-card-selected"
+                    : ""
                 }`}
               >
                 <div className="campaign-card-main">
@@ -224,7 +294,8 @@ export function CampaignsTable({
                   </span>
                   <div className="campaign-progress">
                     <div className="progress-copy">
-                      {campaign.pledgedAmount} / {campaign.targetAmount} {campaign.assetCode}
+                      {campaign.pledgedAmount} / {campaign.targetAmount}{" "}
+                      {campaign.assetCode}
                     </div>
                     <div className="progress-bar" aria-hidden>
                       <div
@@ -235,14 +306,20 @@ export function CampaignsTable({
                     </div>
                   </div>
                   <div className="campaign-meta">
-                    <span className="muted">{campaign.progress.hoursLeft}h left</span>
-                    <span className="muted">{formatTimestamp(campaign.deadline)}</span>
+                    <span className="muted">
+                      {campaign.progress.hoursLeft}h left
+                    </span>
+                    <span className="muted">
+                      {formatTimestamp(campaign.deadline)}
+                    </span>
                   </div>
                 </div>
                 <div className="campaign-card-actions">
                   <button
                     className={
-                      selectedCampaignId === campaign.id ? "btn-secondary" : "btn-ghost"
+                      selectedCampaignId === campaign.id
+                        ? "btn-secondary"
+                        : "btn-ghost"
                     }
                     type="button"
                     onClick={() => onSelect(campaign.id)}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -752,6 +752,64 @@ tbody tr:hover td {
   min-width: 200px;
 }
 
+.status-filter-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.status-filter-tab {
+  min-height: 40px;
+  border-radius: 999px;
+  border: 1px solid var(--border-glass);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-muted);
+  padding: 8px 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.status-filter-tab:hover:not(:disabled) {
+  border-color: var(--border-glass-bright);
+  color: var(--text-main);
+}
+
+.status-filter-tab-active {
+  background: rgba(99, 102, 241, 0.2);
+  border-color: rgba(99, 102, 241, 0.45);
+  color: #c7d2fe;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+}
+
+.status-filter-tab:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.status-filter-count {
+  min-width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-main);
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.status-filter-tab-active .status-filter-count {
+  background: rgba(99, 102, 241, 0.4);
+  color: #eef2ff;
+}
+
 .stacked {
   display: grid;
   gap: 4px;


### PR DESCRIPTION
# Pull Request

## 🗒️ Description

This PR adds status-based campaign filtering so users can isolate actionable campaigns.

Changes included:

- Replaced the status dropdown with explicit filter tabs (All, Open, Funded, Claimed, Failed).
- Added per-status counts to each tab.
- Added clear active-state styling for the selected status.
- Added integration tests for status count labels, active state, and one-status-at-a-time filtering.
- Added optional frontend dummy-data mode for local validation without requiring specific backend campaign states.

## 🔗 Related Issue

- Closes #77
- Fixes #75 

## ✅ Checklist

- [x] My code follows the existing style and patterns of the project.
- [x] I have added/updated tests for my changes.
- [x] All tests pass locally (`npm run test`).
- [ ] If changing the UI, I have added screenshots/videos to this PR.
- [x] My PR has a descriptive title.

## 📸 Screenshots (if applicable)

Add screenshots of:

<img width="843" height="866" alt="image" src="https://github.com/user-attachments/assets/e482e75c-cbd2-4637-8394-a17215ce9ff2" />

## 🛠️ Testing Steps

How can the reviewer verify your changes?

1. In frontend, enable dummy mode by creating/updating [frontend/.env](frontend/.env) with:
   VITE_USE_DUMMY_DATA=true
2. Start the app from [frontend/package.json](frontend/package.json):
   npm run dev
3. Open the Campaign board and click status tabs (All/Open/Funded/Claimed/Failed) to verify:
   - Only one status is shown at a time
   - Active tab is visually distinct
   - Counts appear in each tab label
4. Run targeted test coverage:
   npm test -- --run src/components/CampaignsTable.integration.test.tsx -t "Status Filter Tabs"

---

Thank you for your contribution! 🚀
