### PR TITLE
Implement cancel flow, Freighter pledge enforcement, and API throttling

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -47,6 +47,9 @@ type CampaignListItem = CampaignRecord & { progress: CampaignProgress };
 
 const CAMPAIGN_STATUSES: CampaignStatus[] = ["open", "funded", "claimed", "failed"];
 const CONTRACT_AMOUNT_DECIMALS = Number(process.env.CONTRACT_AMOUNT_DECIMALS ?? 2);
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 120;
+const WRITE_RATE_LIMIT_MAX_REQUESTS = 40;
 
 
 app.use(
@@ -64,6 +67,33 @@ app.use(
 );
 
 app.use(express.json());
+
+const rateLimitBuckets = new Map<string, { count: number; resetAt: number }>();
+
+function applyRateLimit(maxRequests: number) {
+  return (req: Request, res: Response, next: express.NextFunction) => {
+    const key = `${req.ip}:${req.path}:${maxRequests}`;
+    const now = Date.now();
+    const current = rateLimitBuckets.get(key);
+
+    if (!current || now >= current.resetAt) {
+      rateLimitBuckets.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+      return next();
+    }
+
+    if (current.count >= maxRequests) {
+      const retryAfterSec = Math.max(1, Math.ceil((current.resetAt - now) / 1000));
+      res.setHeader("Retry-After", String(retryAfterSec));
+      throw new AppError("Rate limit exceeded. Please retry shortly.", 429, "RATE_LIMITED");
+    }
+
+    current.count += 1;
+    rateLimitBuckets.set(key, current);
+    return next();
+  };
+}
+
+app.use(applyRateLimit(RATE_LIMIT_MAX_REQUESTS));
 
 app.use((req: RequestWithId, res: Response, next: express.NextFunction) => {
   req.requestId = randomUUID();
@@ -263,7 +293,7 @@ app.post("/api/campaigns", (req: Request, res: Response) => {
   res.status(201).json({ data: { ...campaign, progress: calculateProgress(campaign) } });
 });
 
-app.post("/api/campaigns/:id/pledges", (req: Request, res: Response) => {
+app.post("/api/campaigns/:id/pledges", applyRateLimit(WRITE_RATE_LIMIT_MAX_REQUESTS), (req: Request, res: Response) => {
   const parsedId = parseCampaignId(req.params.id);
   if (!parsedId.ok) {
     sendValidationError(parsedId.issues);
@@ -278,7 +308,7 @@ app.post("/api/campaigns/:id/pledges", (req: Request, res: Response) => {
   res.status(201).json({ data: { ...campaign, progress: calculateProgress(campaign) } });
 });
 
-app.post("/api/campaigns/:id/pledges/reconcile", (req: Request, res: Response) => {
+app.post("/api/campaigns/:id/pledges/reconcile", applyRateLimit(WRITE_RATE_LIMIT_MAX_REQUESTS), (req: Request, res: Response) => {
   const parsedId = parseCampaignId(req.params.id);
   if (!parsedId.ok) {
     sendValidationError(parsedId.issues);
@@ -298,7 +328,7 @@ app.post("/api/campaigns/:id/pledges/reconcile", (req: Request, res: Response) =
   });
 });
 
-app.post("/api/campaigns/:id/claim", (req: Request, res: Response) => {
+app.post("/api/campaigns/:id/claim", applyRateLimit(WRITE_RATE_LIMIT_MAX_REQUESTS), (req: Request, res: Response) => {
   const parsedId = parseCampaignId(req.params.id);
   if (!parsedId.ok) {
     sendValidationError(parsedId.issues);
@@ -317,7 +347,7 @@ app.post("/api/campaigns/:id/claim", (req: Request, res: Response) => {
   res.json({ data: { ...campaign, progress: calculateProgress(campaign) } });
 });
 
-app.post("/api/campaigns/:id/refund", async (req: Request, res: Response) => {
+app.post("/api/campaigns/:id/refund", applyRateLimit(WRITE_RATE_LIMIT_MAX_REQUESTS), async (req: Request, res: Response) => {
   const parsedId = parseCampaignId(req.params.id);
   if (!parsedId.ok) {
     sendValidationError(parsedId.issues);

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -14,6 +14,7 @@ pub struct Campaign {
     pub pledged_amount: i128,
     pub deadline: u64,
     pub claimed: bool,
+    pub canceled: bool,
     pub metadata: String,
 }
 
@@ -59,6 +60,13 @@ pub struct CampaignRefunded {
     pub amount: i128,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CampaignCanceled {
+    pub campaign_id: u64,
+    pub creator: Address,
+}
+
 #[contract]
 pub struct StellarGoalVaultContract;
 
@@ -95,6 +103,7 @@ impl StellarGoalVaultContract {
             pledged_amount: 0,
             deadline,
             claimed: false,
+            canceled: false,
             metadata: metadata.clone(),
         };
 
@@ -130,6 +139,9 @@ impl StellarGoalVaultContract {
         let mut campaign = read_campaign(&env, campaign_id);
         if campaign.claimed {
             panic!("campaign already claimed");
+        }
+        if campaign.canceled {
+            panic!("campaign canceled");
         }
         if env.ledger().timestamp() >= campaign.deadline {
             panic!("campaign deadline reached");
@@ -170,6 +182,9 @@ impl StellarGoalVaultContract {
         if campaign.claimed {
             panic!("campaign already claimed");
         }
+        if campaign.canceled {
+            panic!("campaign canceled");
+        }
         if env.ledger().timestamp() < campaign.deadline {
             panic!("campaign is still active");
         }
@@ -204,10 +219,10 @@ impl StellarGoalVaultContract {
         if campaign.claimed {
             panic!("campaign already claimed");
         }
-        if env.ledger().timestamp() < campaign.deadline {
+        if !campaign.canceled && env.ledger().timestamp() < campaign.deadline {
             panic!("campaign is still active");
         }
-        if campaign.pledged_amount >= campaign.target_amount {
+        if !campaign.canceled && campaign.pledged_amount >= campaign.target_amount {
             panic!("funded campaigns cannot be refunded");
         }
 
@@ -233,6 +248,33 @@ impl StellarGoalVaultContract {
                 campaign_id,
                 contributor,
                 amount: contribution,
+            },
+        );
+    }
+
+    pub fn cancel_campaign(env: Env, campaign_id: u64, creator: Address) {
+        creator.require_auth();
+
+        let mut campaign = read_campaign(&env, campaign_id);
+        if campaign.creator != creator {
+            panic!("creator mismatch");
+        }
+        if campaign.claimed {
+            panic!("campaign already claimed");
+        }
+        if campaign.canceled {
+            panic!("campaign already canceled");
+        }
+        campaign.canceled = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Campaign(campaign_id), &campaign);
+
+        env.events().publish(
+            (symbol_short!("Goal"), symbol_short!("Cancel")),
+            CampaignCanceled {
+                campaign_id,
+                creator,
             },
         );
     }

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -212,4 +212,88 @@ mod tests {
         // Second claim must panic
         client.claim(&campaign_id, &creator);
     }
+
+    // -------------------------------------------------------------------------
+    // cancel_campaign + early refund flow
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_cancel_campaign_enables_early_refund() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let creator = Address::generate(&env);
+        let contributor = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let target: i128 = 1_000;
+        let deadline = env.ledger().timestamp() + 1_000;
+
+        let token = deploy_token(&env, &admin, &contributor, target);
+        let client = deploy_contract(&env);
+        let campaign_id = client.create_campaign(
+            &creator,
+            &token,
+            &target,
+            &deadline,
+            &String::from_str(&env, "cancel test"),
+        );
+
+        client.contribute(&campaign_id, &contributor, &300);
+        client.cancel_campaign(&campaign_id, &creator);
+        client.refund(&campaign_id, &contributor);
+
+        let campaign = client.get_campaign(&campaign_id);
+        assert!(campaign.canceled, "campaign must be marked canceled");
+        assert_eq!(campaign.pledged_amount, 0);
+        assert_eq!(client.get_contribution(&campaign_id, &contributor), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "campaign already canceled")]
+    fn test_cancel_campaign_rejects_double_cancel() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let creator = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let contributor = Address::generate(&env);
+        let token = deploy_token(&env, &admin, &contributor, 1_000);
+        let client = deploy_contract(&env);
+        let campaign_id = client.create_campaign(
+            &creator,
+            &token,
+            &500,
+            &(env.ledger().timestamp() + 100),
+            &String::from_str(&env, "double cancel"),
+        );
+        client.cancel_campaign(&campaign_id, &creator);
+        client.cancel_campaign(&campaign_id, &creator);
+    }
+
+    // -------------------------------------------------------------------------
+    // lightweight fuzz-like edge sweep for refund constraints
+    // -------------------------------------------------------------------------
+    #[test]
+    fn test_refund_edge_sweep_non_positive_contributions_after_cancel() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let creator = Address::generate(&env);
+        let contributor = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let token = deploy_token(&env, &admin, &contributor, 10_000);
+        let client = deploy_contract(&env);
+        let campaign_id = client.create_campaign(
+            &creator,
+            &token,
+            &5_000,
+            &(env.ledger().timestamp() + 500),
+            &String::from_str(&env, "edge sweep"),
+        );
+        client.cancel_campaign(&campaign_id, &creator);
+
+        // contributor never pledged; repeated refund attempts must consistently fail
+        for _ in 0..8 {
+            let result = client.try_refund(&campaign_id, &contributor);
+            assert!(result.is_err(), "refund should fail when contribution is zero");
+        }
+    }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,6 @@ import { CreateCampaignForm } from "./components/CreateCampaignForm";
 import { IssueBacklog } from "./components/IssueBacklog";
 import { ToastContainer } from "./components/ToastContainer";
 import {
-  addPledge,
   claimCampaign,
   createCampaign,
   getAppConfig,
@@ -307,26 +306,27 @@ function App() {
     setPendingPledgeCampaignId(campaignId);
 
     try {
-      if (appConfig?.walletIntegrationReady && appConfig.contractId && appConfig.sorobanRpcUrl) {
-        const transactionResult = await submitFreighterPledge({
-          campaignId,
-          contributor: connectedWallet,
-          amount,
-          config: appConfig,
-        });
-
-        await reconcilePledge(campaignId, {
-          contributor: connectedWallet,
-          amount,
-          transactionHash: transactionResult.transactionHash,
-          confirmedAt: transactionResult.confirmedAt,
-        });
-
-        addToast("Pledge confirmed on-chain and reconciled.", "success");
-      } else {
-        await addPledge(campaignId, { contributor: connectedWallet, amount });
-        addToast("Pledge recorded in the local goal vault.", "success");
+      if (!appConfig?.walletIntegrationReady || !appConfig.contractId || !appConfig.sorobanRpcUrl) {
+        throw new Error(
+          "Pledge flow requires Freighter signing and Soroban contract configuration.",
+        );
       }
+
+      const transactionResult = await submitFreighterPledge({
+        campaignId,
+        contributor: connectedWallet,
+        amount,
+        config: appConfig,
+      });
+
+      await reconcilePledge(campaignId, {
+        contributor: connectedWallet,
+        amount,
+        transactionHash: transactionResult.transactionHash,
+        confirmedAt: transactionResult.confirmedAt,
+      });
+
+      addToast("Pledge confirmed on-chain and reconciled.", "success");
 
       await refreshCampaigns(campaignId);
       await refreshSelectedData(campaignId);


### PR DESCRIPTION
## Summary
- add `cancel_campaign` support in the Soroban contract with explicit canceled state/event, block new contributions on canceled campaigns, and allow immediate refund after cancel.
- enforce Freighter-signed pledge submission in the frontend flow (remove local mock pledge fallback in live pledge action path).
- add backend in-memory rate limiting middleware (global + stricter write-path caps) to protect pledge/claim/refund/reconcile endpoints.
- add contract tests for cancel behavior, early refund after cancel, double-cancel rejection, and repeated edge refund attempts.

## Issues
Closes #117
Closes #131
Closes #90
Closes #108

## Validation
- `cargo test` (contracts) ✅
- `npm test -- --run` (frontend) ⚠️ pre-existing unrelated failures in search/debounce/validation tests
- `npm test -- --run` (backend) ⚠️ pre-existing DB init failures in `src/index.test.ts`

Made with [Cursor](https://cursor.com)