### PR TITLE
add architecture decision records for SQLite off-chain MVP and React …

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Contract (`contracts`)
 - Implements `create_campaign`, `contribute`, `claim`, `refund`, `get_campaign`, and `get_contribution`
 - Not yet wired into live wallet signing flow in the frontend
 
+Architecture decision records
+
+- Key architecture choices are documented in `adr/`.
+- See `adr/0001-sqlite-off-chain-mvp.md` for the SQLite off-chain MVP decision.
+- See `adr/0002-react-express-mvp.md` for the React + Express + Soroban MVP architecture decision.
+
 ## Core campaign model
 
 Each campaign stores:

--- a/adr/0001-sqlite-off-chain-mvp.md
+++ b/adr/0001-sqlite-off-chain-mvp.md
@@ -1,0 +1,19 @@
+# 0001 - SQLite Off-chain MVP
+
+Status: Accepted
+
+Context:
+- The project is a lightweight crowdfunding MVP with React, Express, and a Soroban contract scaffold.
+- Early contributors need a simple persistence layer that works reliably for local development and demos.
+- On-chain contract integration is planned but not yet fully wired into the frontend pledge flow.
+
+Decision:
+- Use SQLite for backend persistence of campaigns, pledges, and event history.
+- Keep campaign state and pledge tracking off-chain for the MVP, while preserving the ability to reconcile confirmed on-chain pledges.
+- Store local campaign state in SQLite and expose it through the Express API, with a future path to index blockchain events into the same database.
+
+Consequences:
+- Low infrastructure overhead and fast setup for contributors.
+- A reliable local data source that supports the current React/Express MVP flow.
+- Enables incremental delivery: the app can work before full Soroban wallet integration is complete.
+- Creates a clear migration point for a later production implementation that may move more state on-chain.

--- a/adr/0002-react-express-mvp.md
+++ b/adr/0002-react-express-mvp.md
@@ -1,0 +1,18 @@
+# 0002 - React + Express + Soroban MVP Architecture
+
+Status: Accepted
+
+Context:
+- The product needs a user-facing campaign dashboard and a backend API to manage state, without requiring a full blockchain deployment up front.
+- The Soroban contract scaffold is important for the project roadmap, but the initial experience should still be testable and useful locally.
+
+Decision:
+- Build the frontend as a React + Vite dashboard.
+- Build the backend as an Express REST API backed by SQLite.
+- Keep Soroban contract integration as a separate scaffold and expose contract/network configuration to the frontend for later wallet-enabled workflows.
+
+Consequences:
+- Clear separation between UI, backend state, and eventual blockchain integration.
+- Contributors can work on frontend, API, and contract pieces independently.
+- Provides a practical MVP path that can be extended with on-chain reconciliation and event indexing.
+- Leaves room to improve authentication, rate limiting, and contract synchronization later.


### PR DESCRIPTION
closes #129 

## 🗒️ Description
Added an adr folder with two lightweight Architecture Decision Records:
- `0001-sqlite-off-chain-mvp.md`
- `0002-react-express-mvp.md`

Also updated README.md to reference the new ADR folder and call out the SQLite off-chain MVP decision.

## 🔗 Related Issue
- N/A

## ✅ Checklist
- [x] My code follows the existing style and patterns of the project.
- [ ] I have added/updated tests for my changes.
- [x] All tests pass locally (`npm run test`).
- [ ] If changing the UI, I have added screenshots/videos to this PR.
- [x] My PR has a descriptive title.

## 📸 Screenshots (if applicable)
N/A

## 🛠️ Testing Steps
How can the reviewer verify your changes?
1. Confirm 0001-sqlite-off-chain-mvp.md exists.
2. Confirm 0002-react-express-mvp.md exists.
3. Confirm README.md now includes an `Architecture decision records` section referencing the new ADR files.

---
Thank you for your contribution! 🚀