### PR TITLE
feat: add campaign search api

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,55 +1,53 @@
-# Soft Delete Support for Campaigns - Implementation TODO
+# Backend Search (?search=) Parameter - Implementation TODO
 
 ## Approved Plan Summary
 
-Add soft-delete flag (`deleted_at INTEGER`) to campaigns table. Exclude deleted from default lists. New API for soft-delete. Query param `includeDeleted=true` for maintainers. Preserve history/pledges.
+Add `?search=` query param to GET /api/campaigns filtering titles case-insensitively via SQL LIKE. Map to existing `searchQuery` logic (keep ?q= compat). Restrict to title only. Frontend: integrate server search, remove client-side filtering.
 
 ## Implementation Steps (Complete in order)
 
-### 1. Backend Database Schema Update (db.ts)
+### 1. Create TODO.md and Backend Schema Prep
 
-- Add `deleted_at INTEGER,` to campaigns table in migrate().
-- [x] Edit backend/src/services/db.ts
-- [x] Ran migration
+- [x] Created TODO.md with steps
 
-### 2. Backend Types & campaignStore.ts Updates
+### 2. Backend: Update parseCampaignListFilters in index.ts
 
-- Add `deletedAt?: number` to CampaignRecord, CampaignRow.
-- Update listCampaigns(options): Add `includeDeleted?: boolean` param, WHERE `deleted_at IS NULL OR includeDeleted`.
-- Add `softDeleteCampaign(campaignId: string)`: UPDATE SET deleted_at = now() WHERE id=? AND deleted_at IS NULL.
-- Update rowToCampaign() mapper.
-- [x] Edit backend/src/services/campaignStore.ts
-
-### 3. Backend API Routes (index.ts)
-
-- parseCampaignListFilters(): Add `includeDeleted: req.query.includeDeleted === 'true'`.
-- GET /api/campaigns: Pass includeDeleted to listCampaigns.
-- Add POST /api/campaigns/:id/soft-delete: Auth? Call softDeleteCampaign.
+- Add `search?: unknown` param to parseCampaignListFilters, prefer searchQuery = normalizeQueryValue(query.search) || query.q
+- Pass search: req.query.search in /api/campaigns call
 - [x] Edit backend/src/index.ts
 
-### 4. Frontend Types
+### 3. Backend: Restrict campaignStore.ts SQL to title only
 
-- Add `isDeleted?: boolean` and `deletedAt?: number` to Campaign interface.
-- [x] Edit frontend/src/types/campaign.ts
+- In listCampaigns if(searchQuery): whereClauses.push(`LOWER(title) LIKE ?`); params.push(searchTerm);
+- [x] Edit backend/src/services/campaignStore.ts
 
-### 5. Frontend API Client
-- listCampaigns(filters?: {includeDeleted?: boolean}): Pass param.
-- Add softDeleteCampaign(campaignId): POST /campaigns/${id}/soft-delete.
+### 4. Frontend: Update api.ts listCampaigns
+
+- Accept `filters?: { search?: string; asset?: string; status?: string; includeDeleted?: boolean }`
+- Add params.set('search', filters.search?.trim()); + asset/status
 - [x] Edit frontend/src/services/api.ts
 
-### 6. Frontend UI Updates
+### 5. Frontend: Integrate SearchInput → CampaignsTable server fetch
 
-- CampaignsTable.tsx: Add includeDeleted checkbox (admin), refresh on toggle.
-- CampaignDetailPanel.tsx / CampaignsTable: Add soft-delete button (for creator/maintainer).
-- Handle response: Refresh campaigns list.
-- [x] Edit frontend/src/App.tsx (handler + import)
-- [x] Edit frontend/src/components/CampaignDetailPanel.tsx
+- Add onSearchChange prop to table, useEffect(debouncedSearchQuery => onSearchChange)
+- App.tsx: onSearchChange={(query) => refreshCampaigns(query)}, update refreshCampaigns(searchQuery:string='')
+- Remove debouncedSearchQuery from filteredCampaigns useMemo deps, pass '' to applyFilters
+- Update bootstrap listCampaigns({search:''})
+- [x] Edit frontend/src/components/CampaignsTable.tsx
+- [x] Edit frontend/src/App.tsx
+
+### 6. Frontend: Clean up utils
+
+- Remove searchCampaigns call from applyFilters, comment server-side search
+- [ ] Edit frontend/src/components/campaignsTableUtils.ts
 
 ### 7. Testing & Follow-up
 
-- [ ] Manual test: Create → soft-delete → list excludes → ?includeDeleted=true shows → history intact.
-- [ ] Backend restart/migration: node backend/src/services/db initDb().
-- [ ] Update tests if needed.
+- Backend: Restart, test `curl http://localhost:3001/api/campaigns?search=title`
+- Frontend: `npm run dev`, test search input → server filter, case-insens, empty=all
+- Verify progress fields unchanged
+- E2E test if exists
+- [ ] Update TODO.md on complete
 - [ ] attempt_completion
 
 ## Progress

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -196,6 +196,7 @@ export function parseCampaignListFilters(query: {
   asset?: unknown;
   status?: unknown;
   q?: unknown;
+  search?: unknown;
   includeDeleted?: unknown;
 }): {
   asset?: string;
@@ -206,7 +207,7 @@ export function parseCampaignListFilters(query: {
   return {
     asset: normalizeAssetFilter(query.asset),
     status: normalizeStatusFilter(query.status),
-    searchQuery: normalizeQueryValue(query.q),
+    searchQuery: normalizeQueryValue(query.search) || normalizeQueryValue(query.q),
     includeDeleted: query.includeDeleted === 'true',
   };
 }
@@ -248,12 +249,13 @@ app.get("/api/campaigns", (req: Request, res: Response) => {
     sendValidationError(paginationResult.issues);
   }
 
-  const filters = parseCampaignListFilters({
-    asset: req.query.asset,
-    status: req.query.status,
-    q: req.query.q,
-    includeDeleted: req.query.includeDeleted,
-  });
+    const filters = parseCampaignListFilters({
+      asset: req.query.asset,
+      status: req.query.status,
+      q: req.query.q,
+      search: req.query.search,
+      includeDeleted: req.query.includeDeleted,
+    });
 
   const listOptions: ListCampaignsOptions = {
     searchQuery: filters.searchQuery,

--- a/backend/src/services/campaignStore.ts
+++ b/backend/src/services/campaignStore.ts
@@ -303,12 +303,8 @@ export function listCampaigns(options?: ListCampaignsOptions): ListCampaignsResu
 
   if (options?.searchQuery && options.searchQuery.trim()) {
     const searchTerm = `%${options.searchQuery.trim().toLowerCase()}%`;
-    whereClauses.push(`(
-      LOWER(id) LIKE ? OR
-      LOWER(title) LIKE ? OR
-      LOWER(creator) LIKE ?
-    )`);
-    params.push(searchTerm, searchTerm, searchTerm);
+    whereClauses.push(`LOWER(title) LIKE ?`);
+    params.push(searchTerm);
   }
 
   if (options?.assetCode) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -189,10 +189,10 @@ function App() {
     };
   }, [transactionPreview]);
 
-  async function refreshCampaigns(nextSelectedId?: string | null): Promise<Campaign[]> {
+  async function refreshCampaigns(searchQuery: string = '', nextSelectedId?: string | null): Promise<Campaign[]> {
     setIsCampaignsLoading(true);
     try {
-      const data = await listCampaigns();
+      const data = await listCampaigns({ search: searchQuery });
       setCampaigns(data);
 
       const requestedId = nextSelectedId ?? selectedCampaignId;
@@ -253,7 +253,7 @@ function App() {
       const [configResult, issuesResult, campaignsResult] = await Promise.allSettled([
         getAppConfig(),
         listOpenIssues(),
-        listCampaigns(),
+        listCampaigns({ search: '' }),
       ]);
 
       if (cancelled) {
@@ -627,9 +627,13 @@ function App() {
           campaigns={campaigns}
           selectedCampaignId={selectedCampaignId}
           onSelect={handleSelect}
+          onSearchChange={(query) => {
+            void refreshCampaigns(query);
+          }}
           isLoading={isCampaignsLoading || initialLoad}
           invalidUrlCampaignId={invalidUrlCampaignId}
         />
+
         <CampaignTimeline history={history} isLoading={isSelectedLoading || initialLoad} />
       </section>
 

--- a/frontend/src/components/CampaignsTable.tsx
+++ b/frontend/src/components/CampaignsTable.tsx
@@ -27,6 +27,7 @@ interface CampaignsTableProps {
   campaigns: Campaign[];
   selectedCampaignId: string | null;
   onSelect: (campaignId: string) => void;
+  onSearchChange?: (query: string) => void;
   isLoading?: boolean;
   invalidUrlCampaignId?: string | null;
 }
@@ -66,6 +67,10 @@ export function CampaignsTable({
   const [searchQuery, setSearchQuery] = useState("");
   const debouncedSearchQuery = useDebounce(searchQuery, 300);
 
+  useEffect(() => {
+    onSearchChange?.(debouncedSearchQuery);
+  }, [debouncedSearchQuery, onSearchChange]);
+
   const isEmpty = campaigns.length === 0;
 
   const assetOptions = useMemo(
@@ -95,10 +100,10 @@ export function CampaignsTable({
       campaigns,
       assetCode,
       statusFilter,
-      debouncedSearchQuery,
+      "", // server-side search, no client search
     );
     return sortCampaigns(filtered, sortBy);
-  }, [campaigns, assetCode, statusFilter, debouncedSearchQuery, sortBy]);
+  }, [campaigns, assetCode, statusFilter, sortBy]);
 
   if (isLoading && isEmpty) {
     return (
@@ -210,7 +215,9 @@ export function CampaignsTable({
                   <th>Funding</th>
                   <th>Status</th>
                   <th>Deadline</th>
-                  <th><span className="sr-only">Actions</span></th>
+                  <th>
+                    <span className="sr-only">Actions</span>
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -223,7 +230,13 @@ export function CampaignsTable({
                       </div>
                     </td>
                     <td className="mono">
-                      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                      <div
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 10,
+                        }}
+                      >
                         <AddressAvatar address={campaign.creator} size={28} />
                         <span>{campaign.creator.slice(0, 12)}...</span>
                       </div>

--- a/frontend/src/components/campaignsTableUtils.ts
+++ b/frontend/src/components/campaignsTableUtils.ts
@@ -63,16 +63,12 @@ export function applyFilters(
   status: string,
   searchQuery: string = "",
 ): Campaign[] {
-  // Apply filters in sequence
-  let filtered = searchCampaigns(campaigns, searchQuery);
-
-  filtered = filtered.filter((c) => {
+  // Client-side filters (asset/status only, search is server-side)
+  return campaigns.filter((c) => {
     const matchesAsset = assetCode === "" || c.assetCode === assetCode;
     const matchesStatus = status === "" || c.progress.status === status;
     return matchesAsset && matchesStatus;
   });
-
-  return filtered;
 }
 
 /**

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -31,7 +31,8 @@ async function parseResponse<T>(response: Response): Promise<T> {
       (
         error as Error & { details?: Array<{ field: string; message: string }> }
       ).details = body.error.details;
-      (error as Error & { requestId?: string }).requestId = body.error.requestId;
+      (error as Error & { requestId?: string }).requestId =
+        body.error.requestId;
     }
     throw error;
   }
@@ -39,14 +40,31 @@ async function parseResponse<T>(response: Response): Promise<T> {
   return body;
 }
 
-export async function listCampaigns(filters?: { includeDeleted?: boolean }): Promise<Campaign[]> {
+export async function listCampaigns(filters?: {
+  includeDeleted?: boolean;
+  search?: string;
+  asset?: string;
+  status?: string;
+}): Promise<Campaign[]> {
   const params = new URLSearchParams();
   if (filters?.includeDeleted) {
-    params.set('includeDeleted', 'true');
+    params.set("includeDeleted", "true");
   }
-  const url = `${API_BASE}/campaigns${params.toString() ? `?${params.toString()}` : ''}`;
+  if (filters?.search?.trim()) {
+    params.set("search", filters.search.trim());
+  }
+  if (filters?.asset) {
+    params.set("asset", filters.asset);
+  }
+  if (filters?.status) {
+    params.set("status", filters.status);
+  }
+  const url = `${API_BASE}/campaigns${params.toString() ? `?${params.toString()}` : ""}`;
   const response = await fetch(url);
-  const body = await parseResponse<{ data: Campaign[] }>(response);
+  const body = await parseResponse<{
+    data: Campaign[];
+    pagination?: { total: number };
+  }>(response);
   return body.data;
 }
 
@@ -62,7 +80,9 @@ export async function getAppConfig(): Promise<AppConfig> {
   return body.data;
 }
 
-export async function createCampaign(payload: CreateCampaignPayload): Promise<Campaign> {
+export async function createCampaign(
+  payload: CreateCampaignPayload,
+): Promise<Campaign> {
   const response = await fetch(`${API_BASE}/campaigns`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -89,11 +109,14 @@ export async function reconcilePledge(
   campaignId: string,
   payload: ReconcilePledgePayload,
 ): Promise<{ campaign: Campaign; transactionHash: string }> {
-  const response = await fetch(`${API_BASE}/campaigns/${campaignId}/pledges/reconcile`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
-  });
+  const response = await fetch(
+    `${API_BASE}/campaigns/${campaignId}/pledges/reconcile`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    },
+  );
   const body = await parseResponse<{
     data: { campaign: Campaign; transactionHash: string };
   }>(response);
@@ -116,12 +139,15 @@ export async function claimCampaign(
 }
 
 export async function softDeleteCampaign(campaignId: string): Promise<void> {
-  const response = await fetch(`${API_BASE}/campaigns/${campaignId}/soft-delete`, {
-    method: "POST",
-  });
+  const response = await fetch(
+    `${API_BASE}/campaigns/${campaignId}/soft-delete`,
+    {
+      method: "POST",
+    },
+  );
   if (!response.ok) {
     const content = await response.text();
-    throw new Error(content || 'Soft delete failed');
+    throw new Error(content || "Soft delete failed");
   }
 }
 
@@ -139,7 +165,9 @@ export async function refundCampaign(
   return body.data;
 }
 
-export async function getCampaignHistory(campaignId: string): Promise<CampaignEvent[]> {
+export async function getCampaignHistory(
+  campaignId: string,
+): Promise<CampaignEvent[]> {
   const response = await fetch(`${API_BASE}/campaigns/${campaignId}/history`);
   const body = await parseResponse<{ data: CampaignEvent[] }>(response);
   return body.data;


### PR DESCRIPTION
Closes #97

---

## Summary
Adds backend search support for campaigns via `?search=` query.

## Changes
- Implemented title-based filtering using SQL LIKE
- Made search case-insensitive
- Preserved existing response shape and progress fields

## Behavior
- `?search=` filters campaigns by title
- Empty search returns full list
- Results match main list structure

## Notes
Improves performance by moving search to backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side search for campaigns with case-insensitive title filtering
  * Search now processes in real-time with debounced input that fetches results directly from the server
  * Empty search queries return all available campaigns

* **Refactor**
  * Replaced client-side search filtering with backend-driven search processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->