### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,79 @@
+# Dependabot Configuration
+# See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Backend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "ritik4ever"
+    assignees:
+      - "ritik4ever"
+    labels:
+      - "dependencies"
+      - "backend"
+    groups:
+      backend-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Frontend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "ritik4ever"
+    assignees:
+      - "ritik4ever"
+    labels:
+      - "dependencies"
+      - "frontend"
+    groups:
+      frontend-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Soroban contract Cargo dependencies
+  - package-ecosystem: "cargo"
+    directory: "/contracts"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "ritik4ever"
+    assignees:
+      - "ritik4ever"
+    labels:
+      - "dependencies"
+      - "contracts"
+    groups:
+      contracts-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Closes #283

Adds .github/dependabot.yml with weekly update schedules for:
- npm in backend/ and frontend/
- Cargo in contracts/
- Groups minor and patch updates into single PRs per ecosystem
- Auto-assigns PRs to maintainer for review

**Wallet:** USDT BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3