### PR TITLE
Add Prettier code formatter with consistent configuration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+build
+coverage
+target
+*.wasm

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,18 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "overrides": [
+    {
+      "files": "*.yml",
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #288

Adds .prettierrc with consistent formatting rules:
- Single quotes, semicolons, trailing commas
- 100 character print width
- 2-space tabs
- LF line endings
- .prettierignore for build artifacts and dependencies

**Wallet:** USDT BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3