### PR TITLE
Add pre-commit hooks with Husky and lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,0 +1,9 @@
+{
+  "*.{ts,tsx,js,jsx}": [
+    "prettier --write",
+    "eslint --fix"
+  ],
+  "*.{json,md,yml,css}": [
+    "prettier --write"
+  ]
+}


### PR DESCRIPTION
Closes #282

Adds pre-commit hook configuration:
- Husky pre-commit hook that runs lint-staged
- lint-staged runs prettier and eslint on staged files
- Configuration files for easy setup

**Wallet:** USDT BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3