### PR TITLE
Add Playwright e2e test workflow to CI

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -1,0 +1,86 @@
+name: Playwright E2E Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - 'backend/**'
+      - 'e2e/**'
+      - 'playwright.config.ts'
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - 'backend/**'
+      - 'e2e/**'
+      - 'playwright.config.ts'
+
+jobs:
+  e2e-tests:
+    name: E2E Tests
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: |
+            frontend/package-lock.json
+            backend/package-lock.json
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Start backend
+        working-directory: backend
+        run: |
+          npm run dev &
+          echo "Backend starting..."
+          sleep 3
+        env:
+          NODE_ENV: test
+          PORT: 3001
+
+      - name: Start frontend
+        working-directory: frontend
+        run: |
+          npm run dev &
+          echo "Frontend starting..."
+          sleep 3
+        env:
+          VITE_API_URL: http://localhost:3001/api
+
+      - name: Run Playwright tests
+        run: npx playwright test
+        env:
+          CI: true
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Upload Playwright screenshots on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-screenshots
+          path: test-results/
+          retention-days: 7


### PR DESCRIPTION
Closes #289

Adds a GitHub Actions workflow for Playwright end-to-end testing:
- Installs backend and frontend dependencies
- Starts both services
- Runs Playwright tests
- Uploads test report and screenshots on failure

**Wallet:** USDT BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3