### PR TITLE
Add Vitest coverage threshold of 80% lines

### DIFF
--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -30,8 +30,12 @@ export default defineConfig({
     // Coverage (optional)
     coverage: {
       provider: "v8",
+      provider: "v8",
       reporter: ["text", "json", "html"],
       exclude: ["node_modules/", "tests/", "dist/"],
+      thresholds: {
+        lines: 80,
+      },
     },
   },
 });


### PR DESCRIPTION
Sets coverage.thresholds.lines: 80 in vitest.config.ts so CI fails when coverage drops below 80%.

Closes #312

**Wallet:**
USDC en Stellar: GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF
Alternativa BNB/BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3