### PR TITLE
Add virtual scrolling to campaign list for large datasets

### DIFF
--- a/frontend/src/hooks/useVirtualScroll.ts
+++ b/frontend/src/hooks/useVirtualScroll.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+interface UseVirtualScrollOptions {
+  itemHeight: number;
+  overscan?: number;
+  containerHeight: number;
+  totalItems: number;
+}
+
+export function useVirtualScroll<T>(items: T[], options: UseVirtualScrollOptions) {
+  const { itemHeight, overscan = 5, containerHeight, totalItems } = options;
+  const [visibleRange, setVisibleRange] = useState({ start: 0, end: Math.ceil(containerHeight / itemHeight) + overscan });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleScroll = useCallback(() => {
+    if (!containerRef.current) return;
+    const scrollTop = containerRef.current.scrollTop;
+    const start = Math.floor(scrollTop / itemHeight);
+    const end = start + Math.ceil(containerHeight / itemHeight) + overscan * 2;
+    setVisibleRange({
+      start: Math.max(0, start - overscan),
+      end: Math.min(totalItems, end),
+    });
+  }, [itemHeight, overscan, containerHeight, totalItems]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    container.addEventListener('scroll', handleScroll);
+    return () => container.removeEventListener('scroll', handleScroll);
+  }, [handleScroll]);
+
+  const visibleItems = items.slice(visibleRange.start, visibleRange.end);
+  const totalHeight = totalItems * itemHeight;
+  const offsetY = visibleRange.start * itemHeight;
+
+  return { containerRef, visibleItems, totalHeight, offsetY };
+}


### PR DESCRIPTION
## Summary
Added `useVirtualScroll` hook for efficient rendering of large campaign lists.

## Related Issues
Closes #324

**Wallet:**
USDC Stellar: GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF
BNB/BEP-20: 0x6851F2cCD4C4EA991734FAA83c027A909f2703f3