### PR TITLE
devops: add secret management documentation for GitHub Actions

### DIFF
--- a/docs/secret-management.md
+++ b/docs/secret-management.md
@@ -1,0 +1,27 @@
+# Secret Management
+
+## GitHub Actions Secrets
+
+All secrets are stored in GitHub Actions encrypted secrets. Never hardcode secrets in source code.
+
+### Required Secrets
+
+| Secret Name | Description |
+|-------------|-------------|
+| `STELLAR_SECRET_KEY` | Backend Stellar account secret key |
+| `HORIZON_URL` | Horizon RPC endpoint URL |
+| `SOROBAN_RPC_URL` | Soroban RPC endpoint URL |
+| `WEBHOOK_SECRET` | Webhook signing secret |
+| `DATABASE_URL` | Database connection string |
+
+### Setting Secrets
+
+```bash
+gh secret set STELLAR_SECRET_KEY --repo ritik4ever/stellar-goal-vault
+```
+
+### Rotation Policy
+
+- Rotate secrets every 90 days
+- Rotate immediately if compromised
+- Use different secrets per environment


### PR DESCRIPTION
Closes #310

Adds `docs/secret-management.md` documenting GitHub Actions secrets, setup, and rotation.

**Wallet:**
- Stellar (USDC): `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`
- BNB (BSC): `0x6851F2cCD4C4EA991734FAA83c027A909f2703f3`