### PR TITLE
devops: add autocannon load test to CI on a schedule

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,0 +1,18 @@
+name: Load Test
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  load-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install autocannon
+        run: npm install -g autocannon
+      - name: Run load test
+        run: |
+          autocannon --connections 50 --duration 30 \
+            ${{ secrets.STAGING_URL }}/api/health


### PR DESCRIPTION
Closes #236

Adds GitHub Actions workflow for weekly autocannon load testing against the staging environment.

**Wallet:**
- Stellar (USDC): `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`
- BNB (BSC): `0x6851F2cCD4C4EA991734FAA83c027A909f2703f3`