### PR TITLE
docs: add structured logging documentation with log levels and request IDs

### DIFF
--- a/docs/structured-logging.md
+++ b/docs/structured-logging.md
@@ -1,0 +1,30 @@
+# Structured Logging
+
+## Logger Setup
+
+The backend uses structured JSON logging with the following format:
+
+```json
+{
+  "level": "info",
+  "message": "Request received",
+  "timestamp": "2026-05-28T12:00:00Z",
+  "requestId": "uuid",
+  "method": "GET",
+  "path": "/api/campaigns",
+  "duration": 42
+}
+```
+
+## Log Levels
+
+| Level | Usage |
+|-------|-------|
+| error | Unhandled errors, critical failures |
+| warn | Unexpected but handled situations |
+| info | Normal operational events |
+| debug | Detailed debugging information |
+
+## Request ID Passthrough
+
+All requests should include a unique request ID propagated via the `X-Request-ID` header.


### PR DESCRIPTION
Closes #214

Adds `docs/structured-logging.md` documenting the JSON logging format, log levels, and request ID propagation.

**Wallet:**
- Stellar (USDC): `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`
- BNB (BSC): `0x6851F2cCD4C4EA991734FAA83c027A909f2703f3`