### PR TITLE
docs: add deep health check endpoint documentation

### DIFF
--- a/docs/health-endpoints.md
+++ b/docs/health-endpoints.md
@@ -1,0 +1,33 @@
+# Health Check Endpoints
+
+## GET /api/health
+
+Basic health check. Returns 200 if the server is running.
+
+Response:
+```json
+{
+  "status": "ok",
+  "uptime": 12345
+}
+```
+
+## GET /api/health/deep
+
+Deep health check with component-level status.
+
+Response:
+```json
+{
+  "status": "ok",
+  "components": {
+    "database": { "status": "ok", "latency_ms": 5 },
+    "soroban_rpc": { "status": "ok", "latency_ms": 120 },
+    "horizon": { "status": "ok", "latency_ms": 80 }
+  }
+}
+```
+
+## GET /api/health/ready
+
+Readiness check for load balancers.


### PR DESCRIPTION
Closes #227

Adds `docs/health-endpoints.md` documenting basic, deep, and readiness health check endpoints.

**Wallet:**
- Stellar (USDC): `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`
- BNB (BSC): `0x6851F2cCD4C4EA991734FAA83c027A909f2703f3`