### PR TITLE
Add SQLite index on campaigns.deadline for deadline-based queries

### DIFF
--- a/backend/src/services/db.ts
+++ b/backend/src/services/db.ts
@@ -172,4 +172,10 @@ function migrate(database: SQLiteDatabase): void {
     CREATE INDEX IF NOT EXISTS idx_campaign_events_ledger
     ON campaign_events(json_extract(blockchain_metadata, '$.ledgerNumber'));
   `);
+
+  // Performance indexes for deadline-based and date-based queries (#319)
+  database.exec(`
+    CREATE INDEX IF NOT EXISTS idx_campaigns_deadline ON campaigns(deadline);
+    CREATE INDEX IF NOT EXISTS idx_campaigns_created_at ON campaigns(created_at);
+  `);
 }


### PR DESCRIPTION
## Descripción

Agrega índices SQLite en las columnas `deadline` y `created_at` de la tabla `campaigns` para acelerar las consultas más comunes de ordenamiento y filtrado por fecha.

## Cambios

- Agrega `CREATE INDEX IF NOT EXISTS idx_campaigns_deadline ON campaigns(deadline)` en la migración
- Agrega `CREATE INDEX IF NOT EXISTS idx_campaigns_created_at ON campaigns(created_at)` en la migración
- Los índices se crean con `IF NOT EXISTS` para ser seguros en migraciones subsecuentes

## Testing

- `EXPLAIN QUERY PLAN` antes del índice muestra full table scan; después muestra `SEARCH USING INDEX`
- Todos los tests existentes pasan
- Los nuevos índices no afectan el comportamiento funcional

## Relacionado

Closes #319