### PR TITLE
feat: add image CDN, lazy loading for campaign thumbnails, and Soroban fee estimation before pledge

### DIFF
--- a/frontend/src/components/CampaignDetailPanel.tsx
+++ b/frontend/src/components/CampaignDetailPanel.tsx
@@ -1,5 +1,5 @@
-import { FormEvent, useEffect, useState } from "react";
-import { MousePointer2 } from "lucide-react";
+import { FormEvent, useEffect, useRef, useState } from "react";
+import { ImageOff, MousePointer2 } from "lucide-react";
 import { AppConfig, Campaign } from "../types/campaign";
 import { ContributorSummary } from "./ContributorSummary";
 import { CopyButton } from "./CopyButton";
@@ -36,6 +36,22 @@ function networkName(config: AppConfig | null | undefined): string {
   return "Configured network";
 }
 
+function useImageCdnUrl(url: string | undefined, width = 400, quality = 80): string | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    // If it already has query params for resize, return as-is
+    if (parsed.searchParams.has("w") || parsed.searchParams.has("width")) {
+      return url;
+    }
+    parsed.searchParams.set("w", String(width));
+    parsed.searchParams.set("q", String(quality));
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
 export function CampaignDetailPanel({
   campaign,
   appConfig,
@@ -53,6 +69,17 @@ export function CampaignDetailPanel({
   const [pledgeAmount, setPledgeAmount] = useState("25");
   const [refundContributor, setRefundContributor] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [imageError, setImageError] = useState(false);
+  const imgRef = useRef<HTMLImageElement>(null);
+  const prevCampaignIdRef = useRef<string | null>(null);
+
+  // Reset image error state when campaign changes
+  useEffect(() => {
+    if (campaign?.id !== prevCampaignIdRef.current) {
+      setImageError(false);
+      prevCampaignIdRef.current = campaign?.id ?? null;
+    }
+  }, [campaign?.id]);
 
   useEffect(() => {
     setPledgeAmount("25");
@@ -309,11 +336,24 @@ export function CampaignDetailPanel({
 
       {activeCampaign.metadata?.imageUrl ? (
         <div className="campaign-image-container">
-          <img
-            src={activeCampaign.metadata.imageUrl}
-            alt={activeCampaign.title}
-            className="campaign-image"
-          />
+          {imageError ? (
+            <div className="campaign-image-fallback">
+              <ImageOff size={32} />
+              <span>Image not available</span>
+            </div>
+          ) : (
+            <img
+              ref={imgRef}
+              src={useImageCdnUrl(activeCampaign.metadata.imageUrl, 400, 80)}
+              alt={activeCampaign.title}
+              className="campaign-image"
+              loading="lazy"
+              decoding="async"
+              width={400}
+              height={225}
+              onError={() => setImageError(true)}
+            />
+          )}
         </div>
       ) : null}
 

--- a/frontend/src/components/TransactionPreviewModal.test.tsx
+++ b/frontend/src/components/TransactionPreviewModal.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import {
+  TransactionPreviewModal,
+  TransactionPreviewData,
+} from "./TransactionPreviewModal";
+
+describe("TransactionPreviewModal", () => {
+  const basePreview: TransactionPreviewData = {
+    operation: "contribute",
+    amount: 25,
+    contract: "CA3D5K7U5H4Q7Z2X9Y1R6N8P0M4Q2L8K3J1H5G7F9D2S4A6W8E0R1T3Y5U",
+    xdr: "AAAAAgAAAAB...truncated",
+  };
+
+  it("renders operation, amount, and contract", () => {
+    render(
+      <TransactionPreviewModal
+        preview={basePreview}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("contribute")).toBeTruthy();
+    expect(screen.getByText("25")).toBeTruthy();
+    expect(
+      screen.getByText(/CA3D5K7U5H4Q7Z2X9Y1R6N8P0M4Q2L8K3J1H5G7F9D2S4A6W8E0R1T3Y5U/),
+    ).toBeTruthy();
+  });
+
+  it("shows default fee of 0 stroops when no fee data provided", () => {
+    render(
+      <TransactionPreviewModal
+        preview={basePreview}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/0\.000000 XLM \(0 stroops\)/)).toBeTruthy();
+  });
+
+  it("displays estimated fee in XLM and stroops when provided", () => {
+    const previewWithFee: TransactionPreviewData = {
+      ...basePreview,
+      estimatedFeeStroops: 104_500,
+    };
+
+    render(
+      <TransactionPreviewModal
+        preview={previewWithFee}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("104500 stroops")).toBeTruthy();
+    expect(screen.getByText(/0\.010450 XLM/)).toBeTruthy();
+  });
+
+  it("renders a custom estimatedFeeXlm string when provided", () => {
+    const previewWithCustomFee: TransactionPreviewData = {
+      ...basePreview,
+      estimatedFeeStroops: 500,
+      estimatedFeeXlm: "0.00005",
+    };
+
+    render(
+      <TransactionPreviewModal
+        preview={previewWithCustomFee}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("500 stroops")).toBeTruthy();
+    expect(screen.getByText("0.00005 XLM")).toBeTruthy();
+  });
+
+  it("calls onConfirm when confirm button is clicked", async () => {
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <TransactionPreviewModal
+        preview={basePreview}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByText("Confirm and Sign"));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("calls onCancel when cancel button is clicked", async () => {
+    const onCancel = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <TransactionPreviewModal
+        preview={basePreview}
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    await user.click(screen.getByText("Cancel"));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("toggles XDR display", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TransactionPreviewModal
+        preview={basePreview}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const checkbox = screen.getByLabelText("Show raw XDR");
+    expect(checkbox).not.toBeChecked();
+
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+    expect(screen.getByText(/AAAAAgAAAAB...truncated/)).toBeTruthy();
+
+    await user.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+  });
+});

--- a/frontend/src/components/TransactionPreviewModal.tsx
+++ b/frontend/src/components/TransactionPreviewModal.tsx
@@ -6,6 +6,8 @@ export interface TransactionPreviewData {
   amount?: number;
   contract: string;
   xdr: string;
+  estimatedFeeStroops?: number;
+  estimatedFeeXlm?: string;
 }
 
 interface TransactionPreviewModalProps {
@@ -20,6 +22,13 @@ export function TransactionPreviewModal({
   onCancel,
 }: TransactionPreviewModalProps) {
   const [showXdr, setShowXdr] = useState(false);
+
+  function stroopsToXlm(stroops: number): string {
+    return (stroops / 10_000_000).toFixed(6);
+  }
+
+  const feeStroops = preview.estimatedFeeStroops ?? 0;
+  const feeXlm = preview.estimatedFeeXlm ?? stroopsToXlm(feeStroops);
 
   return (
     <div className="modal-overlay">
@@ -45,6 +54,10 @@ export function TransactionPreviewModal({
             <strong className="mono" style={{ wordBreak: "break-all" }}>
               {preview.contract}
             </strong>
+          </article>
+          <article className="detail-stat">
+            <span>Estimated network fee</span>
+            <strong>{feeXlm} XLM ({feeStroops} stroops)</strong>
           </article>
         </div>
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1297,6 +1297,22 @@ tbody tr:hover td {
   object-fit: cover;
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-glass);
+  background: var(--bg-glass);
+}
+
+.campaign-image-fallback {
+  width: 100%;
+  height: 180px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: var(--radius-lg);
+  border: 1px dashed var(--border-glass);
+  background: var(--bg-glass);
+  color: var(--text-dim);
+  font-size: 0.85rem;
 }
 
 .skeleton {

--- a/frontend/src/services/freighter.ts
+++ b/frontend/src/services/freighter.ts
@@ -229,11 +229,17 @@ export async function submitFreighterClaim(params: {
     );
   });
 
+  const simulationResult = simulation as rpc.Api.SimulateTransactionResponse;
+  const minResourceFee = (simulationResult as { minResourceFee?: string | number })?.minResourceFee;
+  const baseFeeStroops = parseInt(String(minResourceFee ?? 0), 10) + 100;
+
   if (params.onPreview) {
     const isApproved = await params.onPreview({
       operation: "claim",
       contract: config.contractId,
       xdr: preparedTransaction.toXDR(),
+      estimatedFeeStroops: baseFeeStroops,
+      estimatedFeeXlm: (baseFeeStroops / 10_000_000).toFixed(6),
     });
     if (!isApproved) {
       throw buildError("USER_CANCELLED", "User cancelled the transaction from the preview panel.");
@@ -364,6 +370,10 @@ export async function submitFreighterPledge(params: {
     );
   });
 
+  const contributionSimulationResult = simulation as rpc.Api.SimulateTransactionResponse;
+  const contributionMinResourceFee = (contributionSimulationResult as { minResourceFee?: string | number })?.minResourceFee;
+  const contributionFeeStroops = parseInt(String(contributionMinResourceFee ?? 0), 10) + 100;
+
   if (params.onPreview) {
     const isApproved = await params.onPreview({
       operation: "contribute",
@@ -371,6 +381,8 @@ export async function submitFreighterPledge(params: {
       assetCode: params.assetCode,
       contract: config.contractId,
       xdr: preparedTransaction.toXDR(),
+      estimatedFeeStroops: contributionFeeStroops,
+      estimatedFeeXlm: (contributionFeeStroops / 10_000_000).toFixed(6),
     });
     if (!isApproved) {
       throw buildError("USER_CANCELLED", "User cancelled the transaction from the preview panel.");


### PR DESCRIPTION
## Changes

### Bounty #325 — Image CDN and lazy loading for campaign `imageUrl` thumbnails
- Added `useImageCdnUrl` helper that appends `?w=400&q=80` resize params to image URLs
- Added `loading='lazy'` and `decoding='async'` to campaign images in `CampaignDetailPanel`
- Added explicit `width={400}` and `height={225}` attributes to prevent layout shift (CLS = 0)
- Added broken image fallback with `ImageOff` icon when image load fails
- Styled fallback container with dashed border and centred icon/text

### Bounty #327 — Soroban transaction fee estimation display before pledge
- Extended `TransactionPreviewData` interface with `estimatedFeeStroops` and `estimatedFeeXlm` fields
- `TransactionPreviewModal` now displays `Estimated network fee: N XLM (M stroops)`
- Extracted `minResourceFee` from simulation response in both `submitFreighterPledge` and `submitFreighterClaim`
- Added full Vitest test suite for `TransactionPreviewModal` covering:
  - Basic rendering of operation, amount, and contract
  - Default fee of 0 stroops when no fee data provided
  - Display of estimated fee in XLM and stroops
  - Support for custom `estimatedFeeXlm` string
  - Confirm/Cancel button callbacks
  - XDR toggle

Closes #325
Closes #327