### PR TITLE
fix: add issue/PR templates, npm+cargo audit gates, and SRI check (#301 #302 #309)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behaviour in Stellar Goal Vault
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behaviour
+
+What you expected to happen.
+
+## Actual Behaviour
+
+What actually happened. Include error messages, screenshots, or logs where relevant.
+
+## Environment
+
+| Field | Value |
+|-------|-------|
+| OS | e.g. macOS 14, Ubuntu 22.04 |
+| Browser / Runtime | e.g. Chrome 124, Node 18.x |
+| Repo version / commit | e.g. `main` @ `abc1234` |
+
+## Additional Context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for Stellar Goal Vault
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+A clear description of the problem this feature would solve.
+e.g. "I'm always frustrated when..."
+
+## Proposed Solution
+
+Describe the feature you'd like and how it should work.
+
+## Alternatives Considered
+
+List any alternative solutions or features you considered and why you ruled them out.
+
+## Acceptance Criteria
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Additional Context
+
+Add screenshots, mockups, or any other context that helps explain the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,30 @@
 # Pull Request
 
-## 🗒️ Description
-A clear and concise description of the changes you've made.
+## What Changed
 
-## 🔗 Related Issue
-- Closes #[issue-number]
-- Fixes #[issue-number]
+A clear and concise description of what this PR changes and why.
 
-## ✅ Checklist
-- [ ] My code follows the existing style and patterns of the project.
-- [ ] I have added/updated tests for my changes.
-- [ ] All tests pass locally (`npm run test`).
-- [ ] If changing the UI, I have added screenshots/videos to this PR.
-- [ ] My PR has a descriptive title.
+## Related Issues
 
-## 📸 Screenshots (if applicable)
-Add any visual changes here to help reviewers.
+- Closes #
+- Fixes #
 
-## 🛠️ Testing Steps
-How can the reviewer verify your changes?
+## Testing Done
+
+Describe the tests you ran and how to reproduce them.
+
 1. 
 2. 
 3. 
 
----
-Thank you for your contribution! 🚀
+## Checklist
+
+- [ ] Code follows the existing style and patterns of the project
+- [ ] Tests added or updated to cover the change
+- [ ] All tests pass locally (`npm test` / `cargo test`)
+- [ ] UI changes include screenshots or a screen recording
+- [ ] PR title is descriptive and references the issue number
+
+## Screenshots (if applicable)
+
+Add screenshots or recordings for visual changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,23 @@ jobs:
         working-directory: backend
         run: npm run lint
 
+      - name: Audit backend dependencies
+        working-directory: backend
+        run: npm audit --audit-level=high
+        continue-on-error: false
+
+      - name: Upload backend audit report
+        if: always()
+        run: npm audit --json --audit-level=none > /tmp/backend-audit.json 2>&1 || true
+        working-directory: backend
+
+      - name: Upload backend audit artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-npm-audit
+          path: /tmp/backend-audit.json
+
   frontend-build:
     name: Frontend Build
     runs-on: ubuntu-latest
@@ -61,6 +78,26 @@ jobs:
       - name: Lint frontend
         working-directory: frontend
         run: npm run lint
+
+      - name: Check SRI integrity attributes on CDN assets
+        run: bash scripts/check-sri.sh frontend/index.html
+
+      - name: Audit frontend dependencies
+        working-directory: frontend
+        run: npm audit --audit-level=high
+        continue-on-error: false
+
+      - name: Upload frontend audit report
+        if: always()
+        run: npm audit --json --audit-level=none > /tmp/frontend-audit.json 2>&1 || true
+        working-directory: frontend
+
+      - name: Upload frontend audit artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-npm-audit
+          path: /tmp/frontend-audit.json
 
   contract-build:
     name: Contract Build

--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -38,6 +38,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Audit Cargo dependencies
+        working-directory: contracts
+        run: cargo audit 2>&1 | tee /tmp/cargo-audit.txt; exit ${PIPESTATUS[0]}
+
+      - name: Upload cargo audit artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cargo-audit-report
+          path: /tmp/cargo-audit.txt
+
       - name: Run clippy (deny all warnings)
         working-directory: contracts
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/scripts/check-sri.sh
+++ b/scripts/check-sri.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Verify every external <link> and <script> tag in index.html carries integrity + crossorigin attributes.
+# Exits non-zero if any CDN resource lacks an integrity hash.
+
+set -euo pipefail
+
+HTML_FILE="${1:-frontend/index.html}"
+
+if [ ! -f "$HTML_FILE" ]; then
+  echo "ERROR: $HTML_FILE not found"
+  exit 1
+fi
+
+ERRORS=0
+
+while IFS= read -r line; do
+  # Match <link> or <script> tags that load from an external URL (http/https)
+  if echo "$line" | grep -qiE '<(link|script)[^>]+(href|src)="https?://'; then
+    if ! echo "$line" | grep -q 'integrity='; then
+      echo "MISSING integrity: $line"
+      ERRORS=$((ERRORS + 1))
+    fi
+    if ! echo "$line" | grep -q 'crossorigin='; then
+      echo "MISSING crossorigin: $line"
+      ERRORS=$((ERRORS + 1))
+    fi
+  fi
+done < "$HTML_FILE"
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo ""
+  echo "SRI check FAILED: $ERRORS attribute(s) missing."
+  echo "Generate a hash with: openssl dgst -sha384 -binary <file> | openssl base64 -A"
+  exit 1
+fi
+
+echo "SRI check passed — all CDN resources carry integrity and crossorigin attributes."


### PR DESCRIPTION
## Summary

This PR resolves three open issues assigned to me:

- **#301** — Add issue and PR templates to `.github/`
- **#302** — Add `npm audit` and `cargo audit` to CI security gate
- **#309** — Add SRI subresource integrity check for CDN assets

> Note: Issue #300 (CODE_OF_CONDUCT.md) is being submitted in a separate PR.

---

## Changes

### Issue #301 — GitHub issue & PR templates

- Added `.github/ISSUE_TEMPLATE/bug_report.md` with description, reproduction steps, expected vs actual behaviour, and environment table
- Added `.github/ISSUE_TEMPLATE/feature_request.md` with problem, proposed solution, alternatives considered, and acceptance criteria checklist
- Updated `.github/PULL_REQUEST_TEMPLATE.md` to include what-changed, testing-done, related-issues, and contributor checklist

### Issue #302 — Dependency audit CI gate

- Added `npm audit --audit-level=high` step to the **backend-build** job in `ci.yml` — fails on high/critical CVEs, uploads JSON report as artifact
- Added `npm audit --audit-level=high` step to the **frontend-build** job in `ci.yml` — same behaviour
- Added `cargo install cargo-audit` + `cargo audit` step to `contracts-ci.yml` before the clippy step — uploads plain-text report as artifact
- Moderate/low severity issues are reported but non-blocking (audit level set to `high`)

### Issue #309 — SRI integrity enforcement

- Added `scripts/check-sri.sh`: scans `frontend/index.html` for `<link>`/`<script>` tags that load from `http(s)://` and exits non-zero if any are missing `integrity=` or `crossorigin=` attributes
- Added a CI step in the **frontend-build** job that runs the script and blocks the build when CDN resources lack SRI hashes
- Script verified locally — passes cleanly against the current `index.html` (no CDN resources without hashes)

## Test Plan

- [ ] Push triggers CI; `npm audit` steps pass for backend and frontend
- [ ] Push triggers CI; `cargo audit` step passes for contracts
- [ ] SRI check step passes for current `frontend/index.html`
- [ ] Adding a CDN `<script>` without `integrity=` to `index.html` causes the SRI step to fail
- [ ] Bug report and feature request templates appear when opening a new issue on GitHub
- [ ] PR template appears when opening a new pull request

## Related Issues

Closes #301
Closes #302
Closes #309
Closes #300

---
