### PR TITLE
feat: add Escape key to close CampaignDetailPanel (#266)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -180,6 +180,9 @@ function App() {
           transactionPreview.resolve(false);
           setTransactionPreview(null);
         }
+        if (selectedCampaignId) {
+          setSelectedCampaignId(null);
+        }
       }
     };
 
@@ -187,7 +190,7 @@ function App() {
     return () => {
       window.removeEventListener("keydown", handleKeydown);
     };
-  }, [transactionPreview]);
+  }, [transactionPreview, selectedCampaignId]);
 
   async function refreshCampaigns(searchQuery: string = '', nextSelectedId?: string | null): Promise<Campaign[]> {
     setIsCampaignsLoading(true);


### PR DESCRIPTION
## Changes
- Extends existing Escape key handler in App.tsx to close the CampaignDetailPanel
- Pressing Escape now deselects the campaign and closes the detail panel
- Respects existing behavior for shortcuts and transaction preview

Closes #266