### PR TITLE
fix(api): restrict JSON body size to 16kb (#307)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -92,7 +92,8 @@ app.use(
   }),
 );
 
-app.use(express.json());
+const bodySizeLimit = process.env.MAX_BODY_SIZE || "16kb";
+app.use(express.json({ limit: bodySizeLimit }));
 
 // Add API key authentication middleware (production only)
 if (process.env.NODE_ENV === "production") {
@@ -624,6 +625,17 @@ app.get("/api/leaderboard", (req: Request, res: Response) => {
 
 app.use(
   (err: any, req: Request, res: Response, _next: express.NextFunction) => {
+    if (err.type === "entity.too.large") {
+      return res.status(413).json({
+        success: false,
+        error: {
+          code: "PAYLOAD_TOO_LARGE",
+          message: "Request payload size exceeds the maximum allowed limit",
+          requestId: (req as any).requestId,
+        },
+      });
+    }
+
     if (err.message === "Not allowed by CORS") {
       return res.status(403).json({
         success: false,

--- a/backend/tests/integration_test.ts
+++ b/backend/tests/integration_test.ts
@@ -695,6 +695,24 @@ describe("Campaign API - Health & Stability", () => {
     expect(res.data.database.reachable).toBe(true);
   });
 
+  it("should reject payloads larger than the configured limit (413 Payload Too Large)", async () => {
+    // Generate a ~20KB payload
+    const largeDescription = "A".repeat(20 * 1024);
+    
+    const res = await apiClient.post("/api/campaigns", {
+      creator: CREATOR_1,
+      title: "Oversized Campaign",
+      description: largeDescription,
+      assetCode: "USDC",
+      targetAmount: 1000,
+      deadline: nowInSeconds() + 86400,
+    });
+
+    expect(res.status).toBe(413);
+    expect(res.data.success).toBe(false);
+    expect(res.data.error.code).toBe("PAYLOAD_TOO_LARGE");
+  });
+
   it("should handle concurrent requests without data corruption", async () => {
     // Create campaigns concurrently
     const promises = [];


### PR DESCRIPTION
Fixes #307 by configuring express.json to limit request payloads to 16kb, returning a structured 413 Payload Too Large error when exceeded. An integration test has been added to verify oversized payloads are correctly rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Request payload size limits are now configurable (16KB default) to control maximum request sizes accepted by the API
  * API properly rejects oversized requests with appropriate error responses and includes request identifiers for tracking

* **Tests**
  * Integration tests added to verify the API correctly rejects campaign creation requests exceeding size limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->